### PR TITLE
Fix typo: `thewatchman_report.txt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Parse dashboards UI | Parse Dashboards UI (ex-Lovelace) configuration data store
 * *Notification service data*: `{"parse_mode":"html"}`
 
 ## Watchman.report service
-The text version of the report can be generated using `watchman.report` service from Developer Tools UI, an automation or a script. Default location is `/config/thewatchman_report.txt`, which can be altered by `report_path` configuration option. A long report will be split into several messages (chunks) due to limitations imposed by some notification services (e.g., telegram). Service behaviour can be altered with additional optional parameters:
+The text version of the report can be generated using `watchman.report` service from Developer Tools UI, an automation or a script. Default location is `/config/watchman_report.txt`, which can be altered by `report_path` configuration option. A long report will be split into several messages (chunks) due to limitations imposed by some notification services (e.g., telegram). Service behaviour can be altered with additional optional parameters:
 
  - `create_file` create text version of the report (optional, default=true)
  - `send_notification` send report via notification service (optional, default=false)
@@ -202,7 +202,7 @@ service: watchman.report
 data:
   service: telegram_bot.send_document
   data:
-    file: '/config/thewatchman_report.txt'
+    file: '/config/watchman_report.txt'
 ```
 :warning: Whitelisting the configuration folder can be unsafe, use it at your own risk or put report file in a separate folder.
 ```yaml


### PR DESCRIPTION
The generated report is in fact named `watchman_report.txt`, not `thewatchman_report.txt`.

https://github.com/dummylabs/thewatchman/blob/23298faaec5bb1ca21f28124844e86b6b3cbf9fa/custom_components/watchman/const.py#L8