### PR TITLE
also find comments with *only* leading whitespace

### DIFF
--- a/custom_components/watchman/utils.py
+++ b/custom_components/watchman/utils.py
@@ -242,7 +242,7 @@ def parse(hass, folders, ignored_files, root=None):
         r"scene|script|select|sensor|sun|switch|timer|vacuum|weather|zone)\.[A-Za-z_*0-9]+)"
     )
     service_pattern = re.compile(r"service:\s*([A-Za-z_0-9]*\.[A-Za-z_0-9]+)")
-    comment_pattern = re.compile(r"#.*")
+    comment_pattern = re.compile(r"\s*#.*")
     entity_list = {}
     service_list = {}
     effectively_ignored = []


### PR DESCRIPTION
The current comment_pattern only works for those lines where the comment character (#) is at the start of the line. This change extends the pattern to also match those lines with *only* whitespace ahead of them.