### PR TITLE
fix: optional action params

### DIFF
--- a/custom_components/watchman/services.yaml
+++ b/custom_components/watchman/services.yaml
@@ -4,7 +4,7 @@ report:
     parse_config:
       example: true
       default: false
-      required: true
+      required: false
       selector:
         boolean:
     advanced_options:
@@ -34,7 +34,7 @@ report:
         create_file:
           example: true
           default: true
-          required: true
+          required: false
           selector:
             boolean:
 


### PR DESCRIPTION
Action parameters `parse_config` and `create_file` set back to optional to keep compatibility