### PR TITLE
fix: unit tests for #165

### DIFF
--- a/tests/input/test_report1.txt
+++ b/tests/input/test_report1.txt
@@ -8,7 +8,7 @@
 |                                |         | est_services.yaml:1                                          |
 | fake.service2                  | missing | ../../../../../../../../workspaces/thewatchman/tests/input/t |
 |                                |         | est_services.yaml:2                                          |
-| timer.cancel                   | missing | ../../../../../../../../workspaces/thewatchman/tests/input/t |
+| timer_.cancel                  | missing | ../../../../../../../../workspaces/thewatchman/tests/input/t |
 |                                |         | est_services.yaml:3                                          |
 +--------------------------------+---------+--------------------------------------------------------------+
 

--- a/tests/input/test_report4.txt
+++ b/tests/input/test_report4.txt
@@ -28,8 +28,8 @@
 |           |         | _servic  |
 |           |         | es.yaml  |
 |           |         | :2       |
-| timer.c   | missing | ../../.  |
-| ancel     |         | ./../..  |
+| timer_.   | missing | ../../.  |
+| cancel    |         | ./../..  |
 |           |         | /../../  |
 |           |         | ../work  |
 |           |         | spaces/  |

--- a/tests/input/test_services.yaml
+++ b/tests/input/test_services.yaml
@@ -1,6 +1,6 @@
 service: fake.service1
 service: fake.service2
-action: timer.cancel
+action: timer_.cancel
 # below is not an action
 action: one_more
 # action: hello.world action in comment

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -91,7 +91,7 @@ async def test_ignored_items(hass):
     hass.states.async_set("sensor.test3_unavail", "unavailable")
     hass.states.async_set("sensor.test4_avail", "42")
     await async_init_integration(
-        hass, add_params={CONF_IGNORED_ITEMS: "sensor.test1_*, timer.*"}
+        hass, add_params={CONF_IGNORED_ITEMS: "sensor.test1_*, timer_.*"}
     )
     assert len(hass.data[DOMAIN][HASS_DATA_PARSED_ENTITY_LIST]) == 3
     assert len(hass.data[DOMAIN][HASS_DATA_PARSED_SERVICE_LIST]) == 2


### PR DESCRIPTION
By some reason `timer` action is not available in HA within pytest environment, therefore `is_action` check is not working properly and `timer.cancel` entry treated as an entity by Watchman. This leads to unit tests failures. Tests were changed temporary to avoid these errors until issue with timer service is solved. 