### PR TITLE
fix: ignore input_button in "unknown" state #173

### DIFF
--- a/custom_components/watchman/utils/utils.py
+++ b/custom_components/watchman/utils/utils.py
@@ -149,6 +149,8 @@ def get_entity_state(hass, entry, friendly_names=False):
                 state = "disabled"
     else:
         state = str(entity_state.state).replace("unavailable", "unavail")
+        if entry.split(".")[0] == "input_button" and state == "unknown":
+            state = "available"
 
     return state, name
 


### PR DESCRIPTION
Skip input_buttons in "unknown" state from the report fix #173