### PR TITLE
fix: remove date and event from parsing #171

### DIFF
--- a/custom_components/watchman/const.py
+++ b/custom_components/watchman/const.py
@@ -96,6 +96,8 @@ BUNDLED_IGNORED_ITEMS = [
     "timer.started",
     "timer.restarted",
     "timer.paused",
+    "event.*",
+    "date.*",
 ]
 
 # Platforms


### PR DESCRIPTION
`date` and `event` were added as part of standard HA platforms list in #156. Since these two don't have persistent states, they should be excluded from parsing.
fix #171