### PR TITLE
Update to homeassistant 2024.12.1 to fix failing OptionsFlow tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 colorlog==6.8.2
-#homeassistant==2024.6.4
-homeassistant==2024.11.1
+homeassistant==2024.12.1
 pip>=21.3.1
 ruff==0.5.0


### PR DESCRIPTION
## Description

Bumps the `requirements.txt` homeassistant version to 2024.12.1. 

## Motivation and Context

The tests fail with `homeassistant=2024.11.1` due to changes to `OptionsFlowHandler` made in #182, e.g.:
```
FAILED tests/test_config_flow.py::test_options_flow - AttributeError: 'OptionsFlowHandler' object has no attribute 'config_entry'
```

Updating to homeassistant 2024.12.1 fixes this (the HA code change referenced in #182 didn't exist in 2024.11.1).

## How has this been tested?

The tests (i.e. running `scripts/test`) now pass.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
