### PR TITLE
Replace references to 'integration_blueprint' with 'watchman'

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ludeeus/integration_blueprint",
+    "name": "The Watchman dev environment",
     "image": "mcr.microsoft.com/devcontainers/python:3.12",
     "postCreateCommand": "scripts/setup",
     "forwardPorts": [

--- a/scripts/develop
+++ b/scripts/develop
@@ -11,7 +11,7 @@ if [[ ! -d "${PWD}/config" ]]; then
 fi
 
 # Set the path to custom_components
-## This let's us have the structure we want <root>/custom_components/integration_blueprint
+## This lets us have the structure we want <root>/custom_components/watchman
 ## while at the same time have Home Assistant configuration inside <root>/config
 ## without resulting to symlinks.
 export PYTHONPATH="${PYTHONPATH}:${PWD}/custom_components"

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ not_skip = __init__.py
 force_sort_within_sections = true
 sections = FUTURE,STDLIB,INBETWEENS,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 default_section = THIRDPARTY
-known_first_party = custom_components.integration_blueprint, tests
+known_first_party = custom_components.watchman, tests
 combine_as_imports = true
 
 [tool:pytest]

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,6 +8,6 @@ Step 2: run tests: `scripts/test`
 Command | Description
 ------- | -----------
 `pytest tests/` | This will run all tests in `tests/` and tell you how many passed/failed
-`pytest --durations=10 --cov-report term-missing --cov=custom_components.watchman tests` | This tells `pytest` that your target module to test is `custom_components.integration_blueprint` so that it can give you a [code coverage](https://en.wikipedia.org/wiki/Code_coverage) summary, including % of code that was executed and the line numbers of missed executions.
+`pytest --durations=10 --cov-report term-missing --cov=custom_components.watchman tests` | This tells `pytest` that your target module to test is `custom_components.watchman` so that it can give you a [code coverage](https://en.wikipedia.org/wiki/Code_coverage) summary, including % of code that was executed and the line numbers of missed executions.
 `pytest tests/test_init.py -k test_setup_unload_and_reload_entry` | Runs the `test_setup_unload_and_reload_entry` test function located in `tests/test_init.py`
 `pytest --capture=no --log-cli-level=DEBUG tests/` | Do not hide command line output and set log level to debug


### PR DESCRIPTION
## Description

Replaces all the remaning references to `integration_blueprint` (in the README etc) with `watchman`.

## Motivation and Context

I guess these references were just missed when the project was initially set up based on [ludeeus/integration_blueprint](https://github.com/ludeeus/integration_blueprint).

## How has this been tested?

No code was changed (only documentation/comments and the `isort` section of `setup.cfg`) so tests etc are unaffected.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
