### PR TITLE
Fix handling of entities/services mentioned in multiple files #198

### DIFF
--- a/custom_components/watchman/utils/parser.py
+++ b/custom_components/watchman/utils/parser.py
@@ -143,11 +143,7 @@ async def parse(hass, folders, ignored_files, root_path=None):
 
 def add_entry(_list, entry, yaml_file, lineno):
     """Add entry to list of missing entities/services with line number information."""
-    if entry in _list:
-        if yaml_file in _list[entry]:
-            _list[entry].get(yaml_file, []).append(lineno)
-    else:
-        _list[entry] = {yaml_file: [lineno]}
+    _list.setdefault(entry, {}).setdefault(yaml_file, []).append(lineno)
 
 
 def get_included_folders(hass):

--- a/custom_components/watchman/utils/report.py
+++ b/custom_components/watchman/utils/report.py
@@ -173,17 +173,28 @@ def text_renderer(hass, entry_type):
         return f"Text render error: unknown entry type: {entry_type}"
 
 
+def wrap_lines(lines, width):
+    for line in lines:
+        for wrapped_line in wrap(line, width):
+            yield wrapped_line.ljust(width)
+
+
 def fill(data, width, extra=None):
     """Arrange data by table column width."""
+    lines = []
     if data and isinstance(data, dict):
-        key, val = next(iter(data.items()))
-        out = f"{key}:{','.join([str(v) for v in val])}"
-    else:
-        out = str(data) if not extra else f"{data} ('{extra}')"
+        lines = [
+            f"{filename}:" + ",".join(str(n) for n in linenums)
+            for filename, linenums in sorted(data.items())
+        ]
 
-    return (
-        "\n".join([out.ljust(width) for out in wrap(out, width)]) if width > 0 else out
-    )
+    else:
+        lines = [str(data) if not extra else f"{data} ('{extra}')"]
+
+    if width > 0:
+        lines = wrap_lines(lines, width)
+
+    return "\n".join(lines)
 
 
 def get_columns_width(user_width):


### PR DESCRIPTION
## Description

If the same entity or service ID is found in multiple files, only the first file gets reported due to two bugs.

First, when parsing config files `Parser.add_entry()` is missing a branch for what happens if `entry` is in `_list` but `yaml_file` is not in `_list[entry]`:
```
def add_entry(_list, entry, yaml_file, lineno):
    if entry in _list:
        if yaml_file in _list[entry]:
            _list[entry].get(yaml_file, []).append(lineno)
        ### seen 'entry's in new 'yaml_file's get ignored! ###
    else:
        _list[entry] = {yaml_file: [lineno]}
```

Then at report generation time that `_list[entry]` dict gets passed in to `Report.fill()`, which looks at just the first `(filename, line_numbers)` pair as it only calls `next()` once on the `items` iterator:
```
def fill(data, width, extra=None):
    if data and isinstance(data, dict):
        key, val = next(iter(data.items()))
        out = f"{key}:{','.join([str(v) for v in val])}"
...
```

So I fixed up `add_entry` and changed `fill()` to iterate over the whole `data` dict and add a line for each file.

## Motivation and Context

See #198 

## How has this been tested?

The pytest tests (still) pass, and the reproducer in #198 now works as expected:
```
-== Missing 1 entity(ies) from 7 found in your config:
+--------------------------------+----------+--------------------------------------------------------------+
| Entity ID                      | State    | Location                                                     |
+--------------------------------+----------+--------------------------------------------------------------+
| sensor.does_not_exist          | missing  | .storage/lovelace:30                                         |
|                                |          | automations.yaml:6                                           |
+--------------------------------+----------+--------------------------------------------------------------+
```


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
