### PR TITLE
Ignore button in "unknown" state

### DIFF
--- a/custom_components/watchman/utils/utils.py
+++ b/custom_components/watchman/utils/utils.py
@@ -151,6 +151,8 @@ def get_entity_state(hass, entry, friendly_names=False):
         state = str(entity_state.state).replace("unavailable", "unavail")
         if split_entity_id(entry)[0] == "input_button" and state == "unknown":
             state = "available"
+        if split_entity_id(entry)[0] == "button" and state == "unknown":
+            state = "available"
 
     return state, name
 


### PR DESCRIPTION
Like https://github.com/dummylabs/thewatchman/pull/174, but for plain [`button` entities](https://www.home-assistant.io/integrations/button/). Their state is "unknown" after HA starts until they are first pressed.

## How has this been tested?
I have edited the file in my v0.7.0-beta.1 HACS install and verified that unknown button entities are no longer reported.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.