### PR TITLE
Add ignored labels support (#192)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Option | Description | Example
 ------------ | ------------- | -------------
 Folders to watch | Comma-separated list of folders to scan for entities and actions recursively. | `/config`
 Ignored entities and actions | Comma-separated list of items to ignore. The entity/action will be excluded from the report if their name matches a rule from the ignore list. Wildcards are supported, see [example](https://github.com/dummylabs/thewatchman?tab=readme-ov-file#ignored-entities-and-actions-formely-known-as-services-option-example) below. | `sensor.my_sensor1, sensor.my_sensor2`
+Ignored labels | Comma-separated list of label names. Any entity carrying these labels in the entity registry will be excluded from the report. | `ignore_watchman`
 Exclude entity states | Select which states will be excluded from the report | Checkboxes in UI
 Ignored files | Comma-separated list of files and folders to ignore. Wildcards are supported, see [example](https://github.com/dummylabs/thewatchman#ignored-files-option-example) below. Takes precedence over *Included folders* option.| `*/blueprints/*, */custom_components/*, */esphome/*`
 Startup delay | By default, watchman's sensors are updated by `homeassistant_started` event. Some integrations may require extra time for intiialization so that their entities/actions may not yet be ready during watchman check. This is especially true for single-board computers like Raspberry PI. This option allows to postpone startup sensors update for certain amount of seconds. | `0`

--- a/custom_components/watchman/__init__.py
+++ b/custom_components/watchman/__init__.py
@@ -41,6 +41,7 @@ from .const import (
     CONF_HEADER,
     CONF_REPORT_PATH,
     CONF_IGNORED_ITEMS,
+    CONF_IGNORED_LABELS,
     CONF_INCLUDED_FOLDERS,
     CONF_CHECK_LOVELACE,
     CONF_IGNORED_STATES,
@@ -231,7 +232,7 @@ async def add_event_handlers(hass: HomeAssistant):
 
 async def async_migrate_entry(hass, config_entry: ConfigEntry):
     """Migrate ConfigEntry persistent data to a new version."""
-    if config_entry.version > 1:
+    if config_entry.version > CONFIG_ENTRY_VERSION:
         # This means the user has downgraded from a future version
         _LOGGER.error(
             "Unable to migratre Watchman entry from version %d.%d. If integration version was downgraded, use backup to restore its data.",
@@ -239,7 +240,7 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
             config_entry.minor_version,
         )
         return False
-    else:
+    if config_entry.version == 1:
         # migrate from ConfigEntry.options to ConfigEntry.data
         _LOGGER.info(
             "Start Watchman configuration entry migration to version 2. Source data: %s",
@@ -305,3 +306,29 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
             version=CONFIG_ENTRY_VERSION,
         )
         return True
+    if config_entry.version == CONFIG_ENTRY_VERSION and (
+        config_entry.minor_version < CONFIG_ENTRY_MINOR_VERSION
+    ):
+        _LOGGER.info(
+            "Start Watchman configuration entry migration to minor version %d. Source data: %s",
+            CONFIG_ENTRY_MINOR_VERSION,
+            config_entry.data,
+        )
+        data = {**config_entry.data}
+        if CONF_IGNORED_LABELS not in data:
+            data[CONF_IGNORED_LABELS] = DEFAULT_OPTIONS[CONF_IGNORED_LABELS]
+
+        hass.config_entries.async_update_entry(
+            config_entry,
+            data=data,
+            options={**config_entry.options},
+            minor_version=CONFIG_ENTRY_MINOR_VERSION,
+            version=CONFIG_ENTRY_VERSION,
+        )
+        _LOGGER.info(
+            "Successfully migrated Watchman configuration entry to version %d.%d",
+            config_entry.version,
+            CONFIG_ENTRY_MINOR_VERSION,
+        )
+        return True
+    return True

--- a/custom_components/watchman/config_flow.py
+++ b/custom_components/watchman/config_flow.py
@@ -22,6 +22,7 @@ from .const import (
     CONF_HEADER,
     CONF_IGNORED_FILES,
     CONF_IGNORED_ITEMS,
+    CONF_IGNORED_LABELS,
     CONF_IGNORED_STATES,
     CONF_INCLUDED_FOLDERS,
     CONF_REPORT_PATH,
@@ -39,6 +40,7 @@ from .utils.utils import async_is_valid_path, get_val
 
 INCLUDED_FOLDERS_SCHEMA = vol.Schema(vol.All(cv.ensure_list, [cv.string]))
 IGNORED_ITEMS_SCHEMA = vol.Schema(vol.All(cv.ensure_list, [cv.string]))
+IGNORED_LABELS_SCHEMA = vol.Schema(vol.All(cv.ensure_list, [cv.string]))
 IGNORED_STATES_SCHEMA = vol.Schema(MONITORED_STATES)
 IGNORED_FILES_SCHEMA = vol.Schema(vol.All(cv.ensure_list, [cv.string]))
 COLUMNS_WIDTH_SCHEMA = vol.Schema(vol.All(cv.ensure_list, [cv.positive_int]))
@@ -53,6 +55,9 @@ def _get_data_schema() -> vol.Schema:
             ): select,
             vol.Optional(
                 CONF_IGNORED_ITEMS,
+            ): select,
+            vol.Optional(
+                CONF_IGNORED_LABELS,
             ): select,
             vol.Optional(
                 CONF_IGNORED_STATES,

--- a/custom_components/watchman/const.py
+++ b/custom_components/watchman/const.py
@@ -7,7 +7,7 @@ DOMAIN_DATA = "watchman_data"
 VERSION = "0.7.0-beta.1"
 
 CONFIG_ENTRY_VERSION = 2
-CONFIG_ENTRY_MINOR_VERSION = 1
+CONFIG_ENTRY_MINOR_VERSION = 2
 
 DEFAULT_REPORT_FILENAME = "watchman_report.txt"
 DEFAULT_HEADER = "-== WATCHMAN REPORT ==- "
@@ -40,6 +40,7 @@ CONF_IGNORED_FILES = "ignored_files"
 CONF_HEADER = "report_header"
 CONF_REPORT_PATH = "report_path"
 CONF_IGNORED_ITEMS = "ignored_items"
+CONF_IGNORED_LABELS = "ignored_labels"
 CONF_SERVICE_NAME = "service"
 CONF_ACTION_NAME = "action"
 CONF_SERVICE_DATA = "data"
@@ -107,6 +108,7 @@ PLATFORMS = [Platform.SENSOR]
 DEFAULT_OPTIONS = {
     CONF_INCLUDED_FOLDERS: "/config",
     CONF_IGNORED_ITEMS: "",
+    CONF_IGNORED_LABELS: "",
     CONF_IGNORED_STATES: [],
     CONF_IGNORED_FILES: "*/blueprints/*, */custom_components/*, */esphome/*",
     CONF_CHECK_LOVELACE: False,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,6 +9,7 @@ from custom_components.watchman.const import (
     DOMAIN,
     CONF_INCLUDED_FOLDERS,
     DEFAULT_OPTIONS,
+    CONFIG_ENTRY_MINOR_VERSION,
 )
 
 
@@ -33,6 +34,7 @@ async def async_init_integration(
             title="WM",
             unique_id="unique_id",
             version=2,
+            minor_version=CONFIG_ENTRY_MINOR_VERSION,
             data=config,
         )
     config_entry.add_to_hass(hass)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,10 +3,12 @@
 from homeassistant.setup import async_setup_component
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import label_registry as lr
 from . import async_init_integration
 
 from custom_components.watchman.const import (
     CONF_IGNORED_ITEMS,
+    CONF_IGNORED_LABELS,
     CONF_IGNORED_STATES,
     DOMAIN,
     CONF_IGNORED_FILES,
@@ -97,3 +99,35 @@ async def test_ignored_items(hass):
     assert len(hass.data[DOMAIN][HASS_DATA_PARSED_SERVICE_LIST]) == 2
     assert len(hass.data[DOMAIN][HASS_DATA_MISSING_ENTITIES]) == 2
     assert len(hass.data[DOMAIN][HASS_DATA_MISSING_SERVICES]) == 2
+
+
+async def test_ignored_labels(hass):
+    """Test ignored labels processing."""
+    label_registry = lr.async_get(hass)
+    ignored_label = label_registry.async_create("ignore_watchman")
+    ignored_label_id = getattr(ignored_label, "label_id", None) or getattr(
+        ignored_label, "id", None
+    )
+    assert ignored_label_id
+
+    entity_registry = er.async_get(hass)
+    reg_entry = entity_registry.async_get_or_create(
+        "sensor",
+        "watchman",
+        "test1_unknown",
+        suggested_object_id="test1_unknown",
+    )
+    entity_registry.async_update_entity(reg_entry.entity_id, labels={ignored_label_id})
+
+    hass.states.async_set("sensor.test1_unknown", "unknown")
+    hass.states.async_set("sensor.test2_missing", "missing")
+    hass.states.async_set("sensor.test3_unavail", "unavailable")
+    hass.states.async_set("sensor.test4_avail", "42")
+
+    await async_init_integration(
+        hass, add_params={CONF_IGNORED_LABELS: "ignore_watchman"}
+    )
+
+    # entity with ignored label is excluded from missing entities report
+    assert len(hass.data[DOMAIN][HASS_DATA_MISSING_ENTITIES]) == 2
+    assert len(hass.data[DOMAIN][HASS_DATA_MISSING_SERVICES]) == 3

--- a/tests/test_y_entry_migration.py
+++ b/tests/test_y_entry_migration.py
@@ -11,6 +11,7 @@ from custom_components.watchman.const import (
     CONF_FRIENDLY_NAMES,
     CONF_HEADER,
     CONF_IGNORED_FILES,
+    CONF_IGNORED_LABELS,
     CONF_IGNORED_ITEMS,
     CONF_IGNORED_STATES,
     CONF_INCLUDED_FOLDERS,
@@ -113,6 +114,8 @@ async def test_entry_migration_1to2(
     assert mock_config_entry.data[CONF_SECTION_APPEARANCE_LOCATION][
         CONF_COLUMNS_WIDTH
     ] == from_list(old_config[CONF_COLUMNS_WIDTH])
+
+    assert CONF_IGNORED_LABELS in mock_config_entry.data
 
     # === nofity_action section ===
     assert CONF_SECTION_NOTIFY_ACTION not in mock_config_entry.data


### PR DESCRIPTION
## Description
Add support for ignoring entities by label name, including config option, migration default for existing installations, and runtime filtering in missing-entity checks for labeled entities. Add README entry and tests covering label ignore behavior.

## Motivation and Context
Enable users to exclude labeled entities from Watchman reports. Fixes #192.

## How has this been tested?
I have run the test suite in a container and loaded the code onto my live home assistant installation.  I did manual smoke testing.

## Screenshots (if appropriate):
<img width="452" height="891" alt="image" src="https://github.com/user-attachments/assets/af3a5ccd-4a32-4810-b6d9-3d9d6fa31693" />


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.


