### PR TITLE
fix: support registry-disabled automations

### DIFF
--- a/tests/tests/test_disabled_warnings.py
+++ b/tests/tests/test_disabled_warnings.py
@@ -1,0 +1,101 @@
+"""Test handling of disabled automations warnings."""
+from unittest.mock import MagicMock, patch
+
+from custom_components.watchman.const import (
+    CONF_EXCLUDE_DISABLED_AUTOMATION,
+    CONF_IGNORED_STATES,
+)
+from custom_components.watchman.coordinator import (
+    FilterContext,
+    WatchmanCoordinator,
+    renew_missing_items_list,
+)
+from custom_components.watchman.utils.utils import set_obfuscation_config
+import pytest
+from homeassistant.helpers import entity_registry as er
+
+@pytest.mark.asyncio
+async def test_registry_disabled_automation_warning_suppression(hass):
+    """Test that warnings are suppressed for registry-disabled automations."""
+    # Disable obfuscation for clear assertions
+    set_obfuscation_config(False)
+    
+    # Setup Entity Registry
+    registry = er.async_get(hass)
+    
+    # Create a registry-disabled automation
+    # We use async_get_or_create to add it
+    entry = registry.async_get_or_create(
+        "automation",
+        "test",
+        "disabled_auto",
+        suggested_object_id="disabled_auto",
+        disabled_by=er.RegistryEntryDisabler.USER
+    )
+    
+    # Create an active automation (state 'on')
+    registry.async_get_or_create(
+        "automation",
+        "test",
+        "active_auto",
+        suggested_object_id="active_auto",
+    )
+    hass.states.async_set("automation.active_auto", "on")
+    
+    # Create an automation that is missing from registry AND states (should warn)
+    # No registry entry, no state
+    
+    # Mock Hub (minimal)
+    hub = MagicMock()
+    
+    # Mock Config Entry
+    config_entry = MagicMock()
+    config_entry.data = {}
+    config_entry.title = "Test"
+    
+    # Init Coordinator
+    coordinator = WatchmanCoordinator(hass, None, config_entry, hub, "1.0")
+    
+    # Patch config to enable exclude_disabled (so build_filter_context logic runs fully)
+    with patch("custom_components.watchman.coordinator.get_config", side_effect=lambda h, k, d=None: True if k == CONF_EXCLUDE_DISABLED_AUTOMATION else d):
+        
+        # 1. Verify _build_filter_context logic
+        # It should identify automation.disabled_auto as disabled
+        ctx = coordinator._build_filter_context()
+        
+        assert "automation.disabled_auto" in ctx.disabled_automations
+        assert "automation.active_auto" not in ctx.disabled_automations
+        
+        # 2. Verify renew_missing_items_list logic
+        # parsed_list simulates entities used by these automations
+        parsed_list = {
+            "sensor.test_disabled": {
+                "automations": ["automation.disabled_auto"],
+                "locations": {"test.yaml": [1]},
+                "occurrences": []
+            },
+            "sensor.test_missing": {
+                "automations": ["automation.missing_auto"],
+                "locations": {"test.yaml": [2]},
+                "occurrences": []
+            }
+        }
+        
+        # Capture logs
+        with patch("custom_components.watchman.coordinator._LOGGER") as mock_logger:
+            renew_missing_items_list(hass, parsed_list, ctx, "entity")
+            
+            # Should warn for missing_auto
+            # We expect warning: "? Unable to locate automation: automation.missing_auto ..."
+            
+            # Should NOT warn for disabled_auto
+            
+            warnings = [call[0][0] for call in mock_logger.warning.call_args_list]
+            
+            # Check for missing_auto warning
+            missing_warned = any("automation.missing_auto" in w for w in warnings)
+            assert missing_warned, f"Should warn about truly missing automation. Warnings: {warnings}"
+            
+            # Check for disabled_auto warning
+            disabled_warned = any("automation.disabled_auto" in w for w in warnings)
+            assert not disabled_warned, "Should NOT warn about registry-disabled automation"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Optimize WatchmanCoordinator to reduce CPU usage and fix a false positive warning.
**Optimization:** The `_build_filter_context` method currently iterates over the Entity Registry to build a map, and separately over `hass.states `to find disabled automations. We must merge this into a single efficient pass over the Entity Registry.
**Bugfix**: The `renew_missing_items_list` function warns "Unable to locate automation" for automations disabled via the Registry (as they are absent from `hass.states`). This warning should be suppressed for disabled automations.

## Motivation and Context

- Get rid of warning in Watchman logs for automations disabled in entity registry.
- Improve performance of `coordinator.async_update_data`

## How has this been tested?

Automatic tests passed.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
