### PR TITLE
fix: exclude `logger` configuration key from parsing

### DIFF
--- a/custom_components/watchman/utils/parser_const.py
+++ b/custom_components/watchman/utils/parser_const.py
@@ -9,22 +9,30 @@ JSON_FILE_EXTS = {'.config_entries'}
 STORAGE_WHITELIST = {'lovelace', 'lovelace_dashboards', 'lovelace_resources', 'core.config_entries'}
 MAX_FILE_SIZE = 500 * 1024  # 500 KB
 
+# A fallback list of Home Assistant entity platforms for the CLI parser.
+# This list is used ONLY when the 'homeassistant' library is not importable.
+# If the library is present, this list is overwritten by the official constants.
+# DO NOT EXTEND this list for missing integration domains; use HA_DOMAINS instead.
 PLATFORMS = [
     "ai_task", "air_quality", "alarm_control_panel", "assist_satellite", "binary_sensor", "button",
     "calendar", "camera", "climate", "conversation", "cover", "date", "datetime", "device_tracker",
     "event", "fan", "geo_location", "humidifier", "image", "image_processing", "lawn_mower",
     "light", "lock", "media_player", "notify", "number", "remote", "scene", "select", "sensor",
     "siren", "stt", "switch", "text", "time", "todo", "tts", "update", "vacuum", "valve",
-    "wake_word", "water_heater", "weather",
+    "wake_word", "water_heater", "weather"
 ]
 
+
+# Integration domains used as a fallback for the standalone CLI parser.
+# In runtime, this list is merged with `hass.config.components`.
+# It includes standard domains (e.g., 'automation') and common integrations for testing.
 HA_DOMAINS = [
     "automation", "script", "group", "zone", "person", "sun", "input_boolean", "input_button",
     "input_datetime", "input_number", "input_select", "input_text", "timer", "counter",
     "shell_command", "persistent_notification", "homeassistant", "system_log", "logger",
     "recorder", "history", "logbook", "map", "mobile_app", "tag", "webhook", "websocket_api",
     "ble_monitor", "hassio", "mqtt", "python_script", "speedtestdotnet", "telegram_bot",
-    "xiaomi_miio", "yeelight", "alert", "plant", "proximity", "schedule"
+    "xiaomi_miio", "yeelight", "alert", "plant", "proximity", "schedule", "template"
 ]
 
 # following patterns are ignored by watchman as they are neither entities, nor actions
@@ -40,7 +48,7 @@ ESPHOME_PATH_SEGMENT = "esphome"
 ESPHOME_ALLOWED_KEYS = {'service', 'action', 'entity_id'}
 
 # YAML keys which values (whole hierarchy) should be ignored
-IGNORED_BRANCH_KEYS = {'url', 'example', 'description', 'event_type'}
+IGNORED_BRANCH_KEYS = {'url', 'example', 'description', 'event_type', 'logger'}
 
 # Keys where the parser ignores the immediate string value (to avoid false positives)
 # but continues recursion if the value is a complex structure


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Excludes the `logger:` key and its content from the parsing process.

## Motivation and Context

The Home Assistant logger configuration often triggers false positives because integration IDs can be easily mistaken for entity definitions (e.g. `template.py` as mentioned in #252). Since logger settings are not related to actual entities or actions, this block is now excluded to improve accuracy.

## How has this been tested?

Automatic tests passed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
