### PR TITLE
perf: incremental state update in coordinator

### DIFF
--- a/custom_components/watchman/__init__.py
+++ b/custom_components/watchman/__init__.py
@@ -124,7 +124,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: WMConfigEntry) ->
             f"Executing mandatory startup scan in: {startup_delay}s."
         )
 
-        coordinator.request_parser_rescan(reason="mandatory startup scan", delay=startup_delay)
+        coordinator.request_parser_rescan(reason="integration reload", delay=startup_delay)
 
     _LOGGER.info(
         "Watchman integration started [%s], DB: %s, Stats: %s",

--- a/custom_components/watchman/services.py
+++ b/custom_components/watchman/services.py
@@ -96,7 +96,9 @@ class WatchmanServicesSetup:
             # Blocking wait for a fresh scan
             await self.coordinator.async_force_parse()
         else:
-            # Just refresh sensors from existing DB (in case something changed externally)
+            # FIX: Ensure sensors perform a FULL check to match the generated report,
+            # ignoring the incremental optimization.
+            self.coordinator._force_full_rescan = True
             await self.coordinator.async_request_refresh()
 
         # call notification action even when send notification = False

--- a/tests/tests/test_coordinator_optimization.py
+++ b/tests/tests/test_coordinator_optimization.py
@@ -48,6 +48,8 @@ async def test_incremental_update(hass, tmp_path):
 @pytest.mark.asyncio
 async def test_interleaved_events(hass, tmp_path, caplog):
     """Test race condition: Dirty set followed by Global Context change triggers Full Rescan."""
+    import logging
+    caplog.set_level(logging.DEBUG, logger="custom_components.watchman")
     # 1. Setup
     config_dir = tmp_path / "config"
     config_dir.mkdir()
@@ -95,7 +97,7 @@ async def test_interleaved_events(hass, tmp_path, caplog):
         assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 0, "Entities should be found (0 missing)"
         
         # Check logs for Full Rescan path
-        assert "Performing FULL status check." in caplog.text
+        assert "performing FULL status check." in caplog.text
         # Mock verification (optional if logs checked, but good double check)
         assert mock_renew.called, "Full rescan SHOULD happen"
         

--- a/tests/tests/test_event_noise_reduction.py
+++ b/tests/tests/test_event_noise_reduction.py
@@ -1,0 +1,72 @@
+"""Test Watchman Event Noise Reduction logic."""
+import pytest
+from unittest.mock import patch, MagicMock
+from homeassistant.const import EVENT_STATE_CHANGED
+from custom_components.watchman.const import DOMAIN, CONF_INCLUDED_FOLDERS
+from custom_components.watchman.coordinator import WatchmanCoordinator
+from tests import async_init_integration
+
+@pytest.mark.asyncio
+async def test_event_noise_reduction(hass, tmp_path):
+    """Test that irrelevant state changes are filtered out."""
+    # 1. Setup
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "test.yaml").write_text("sensor:\n  - platform: template\n    sensors:\n      test:\n        value_template: '{{ states.sensor.noise_test }}'", encoding="utf-8")
+
+    await async_init_integration(hass, add_params={CONF_INCLUDED_FOLDERS: str(config_dir)})
+    await hass.async_block_till_done()
+
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    # Helper to simulate state change and check if refresh called
+    async def verify_event(old_state_val, new_state_val, should_trigger):
+        with patch.object(coordinator, "async_request_refresh") as mock_refresh:
+            old = MagicMock(state=old_state_val) if old_state_val is not None else None
+            new = MagicMock(state=new_state_val) if new_state_val is not None else None
+            
+            hass.bus.async_fire(EVENT_STATE_CHANGED, {
+                "entity_id": "sensor.noise_test",
+                "old_state": old,
+                "new_state": new
+            })
+            await hass.async_block_till_done()
+            
+            if should_trigger:
+                assert mock_refresh.called, f"Should trigger for {old_state_val} -> {new_state_val}"
+                assert "sensor.noise_test" in coordinator._dirty_entities
+            else:
+                assert not mock_refresh.called, f"Should NOT trigger for {old_state_val} -> {new_state_val}"
+
+    # 1. Active -> Active (1 -> 2)
+    # Should IGNORE
+    await verify_event("1", "2", False)
+
+    # 2. Attribute Change (1 -> 1)
+    # Should IGNORE
+    await verify_event("1", "1", False)
+
+    # 3. Missing -> Active (unavailable -> on)
+    # Should CAPTURE
+    await verify_event("unavailable", "on", True)
+    coordinator._dirty_entities.clear() # Reset
+
+    # 4. Active -> Missing (on -> unavailable)
+    # Should CAPTURE
+    await verify_event("on", "unavailable", True)
+    coordinator._dirty_entities.clear()
+
+    # 5. Entity Creation (None -> on)
+    # Should CAPTURE
+    await verify_event(None, "on", True)
+    coordinator._dirty_entities.clear()
+
+    # 6. Missing -> Missing (unknown -> unavailable)
+    # Should IGNORE
+    await verify_event("unknown", "unavailable", False)
+
+    # 7. Entity Removal (on -> None)
+    # Should CAPTURE
+    await verify_event("on", None, True)
+    coordinator._dirty_entities.clear()

--- a/tests/tests/test_report_sensor_sync.py
+++ b/tests/tests/test_report_sensor_sync.py
@@ -1,0 +1,62 @@
+"""Test Watchman Report and Sensor synchronization."""
+from datetime import timedelta
+from unittest.mock import patch, MagicMock
+import pytest
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+from custom_components.watchman.const import DOMAIN, CONF_INCLUDED_FOLDERS, COORD_DATA_MISSING_ENTITIES
+from custom_components.watchman.coordinator import WatchmanCoordinator
+from tests import async_init_integration
+
+@pytest.mark.asyncio
+async def test_report_service_forces_full_rescan(hass, tmp_path):
+    """Test that watchman.report service forces a full rescan of sensors."""
+    # 1. Setup: Config with 1 missing entity
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "test.yaml").write_text("sensor:\n  - platform: template\n    sensors:\n      test:\n        value_template: '{{ states.sensor.sync_test }}'", encoding="utf-8")
+
+    await async_init_integration(hass, add_params={CONF_INCLUDED_FOLDERS: str(config_dir)})
+    await hass.async_block_till_done()
+
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    # Verify initial state: 1 missing entity
+    assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 1
+    
+    # 2. Action: Set flag to False to simulate cached state
+    coordinator._force_full_rescan = False
+    coordinator._dirty_entities.clear()
+    
+    # Change state of the entity in HA but avoid triggering the coordinator's listener 
+    # (or just assume we want to prove Branch A is taken regardless of dirty set)
+    hass.states.async_set("sensor.sync_test", "on")
+    # Coordinator would usually be notified and set dirty, but we want to test the report service override.
+    # To be absolutely sure we test the override, we clear dirty entities again.
+    coordinator._dirty_entities.clear()
+    
+    # At this point:
+    # _force_full_rescan = False
+    # _dirty_entities = empty
+    # If we call refresh now, it would return 1 (cached).
+    
+    # 3. Call watchman.report service
+    import custom_components.watchman.coordinator as coord_module
+    original_renew = coord_module.renew_missing_items_list
+    
+    with patch("custom_components.watchman.coordinator.renew_missing_items_list", wraps=None) as mock_renew:
+        # We need the real function to execute so sensors update
+        mock_renew.side_effect = original_renew
+        
+        await hass.services.async_call(DOMAIN, "report", {"create_file": False}, blocking=True)
+        
+        # Service call schedules refresh. Trigger debounce.
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
+        await hass.async_block_till_done()
+        
+        # Verify Branch A (Full Rescan) was taken
+        assert mock_renew.called, "Full rescan SHOULD be forced by report service"
+        
+    # 4. Assert Final State: Sensors should be 0
+    assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 0

--- a/tests/tests/test_startup_delay.py
+++ b/tests/tests/test_startup_delay.py
@@ -40,7 +40,7 @@ async def test_startup_delay_on_ha_start(hass: HomeAssistant):
         calls = mock_rescan.call_args_list
         startup_call = None
         for call in calls:
-            if call.kwargs.get("reason") == "mandatory startup scan":
+            if call.kwargs.get("reason") == "integration reload":
                 startup_call = call
                 break
 
@@ -65,7 +65,7 @@ async def test_startup_delay_when_ha_running(hass: HomeAssistant):
         calls = mock_rescan.call_args_list
         startup_call = None
         for call in calls:
-            if call.kwargs.get("reason") == "mandatory startup scan":
+            if call.kwargs.get("reason") == "integration reload":
                 startup_call = call
                 break
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR implements a major performance optimization for the `WatchmanCoordinator` by shifting from a **Full Rescan** strategy to an **Incremental "Dirty Set"** strategy for processing state changes within `_async_update_data` function.

**Key Changes:**
- **Incremental Updates:** Instead of re-evaluating the status of _all_ monitored items every time a single entity changes state, the coordinator now tracks changed entity IDs in a `_dirty_entities` set. When the debounce timer expires, only these specific entities are re-checked against the filter rules.
- **Logic Refactoring:** Extracted the core validation logic from `renew_missing_items_list` into a reusable helper `check_single_entity_status`.
- **Event Noise Filtering:** The event listener `_handle_state_change_event` has been hardened to ignore irrelevant events, such as:
    - Attribute-only changes (where `state.state` remains the same).
    - Transitions between two "Available" states (e.g., numeric sensor changing value) or two "Missing" states.
    - It now only queues an update when an entity transitions from **Available ↔ Missing**
- **Full rescan:** Introduced a `_force_full_rescan` flag. Global context changes that affect multiple entities (e.g., toggling an automation, modifying the Entity Registry, or reloading configuration) bypass the incremental logic and trigger a safe Full Rescan to guarantee consistency.
- **Service Fix:** Updated `watchman.report` to force a full rescan before generating a report, ensuring the sensors and the text report are always in sync.

## Motivation and Context

**The Problem:**

Previously, the integration performed a full iteration over all monitored entities (regex matching, registry lookups, automation mapping) whenever _any_ monitored entity changed its state. Monitored here all entities found by parser in user's configration files.

In installations with a large number of entities (1K+) or frequent state changes, this caused significant CPU overhead and unnecessary processing, as 99% of the entities had not changed their "missing" status.

**The Solution:**

By implementing the **Dirty Set** pattern:
1. **Performance:** The computational cost of an update is now proportional to the number of _changed_ entities (usually 1-5), not the total number of _monitored_ entities (potentially thousands).
2. **Scalability:** The integration impacts the event loop significantly less, making it suitable for larger Home Assistant installations.
3. **Efficiency:** "Noisy" sensors (e.g., power meters updating every second) are now effectively filtered out at the listener level if their availability status hasn't changed.

## How has this been tested?

Existing tests passed. New tests added:
- `test_incremental_update`: Verifies that a single entity state change triggers only a partial update, strictly avoiding the heavy full rescan logic.
- `test_interleaved_events`: Ensures that a Full Rescan (e.g., from a config reload) takes precedence over pending incremental updates during race conditions, guaranteeing data consistency.
- `test_debounce_flip_flop`: Confirms that the coordinator correctly resolves the final state of an entity that toggles multiple times (Active ↔ Missing) within the debounce window.
- `test_unknown_entity`: Verifies stability and counter integrity when processing state change events from entities not monitored by Watchman.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
