### PR TITLE
fix: parser bug with redundant regexp definitions + refactoring 

### DIFF
--- a/custom_components/watchman/utils/parser_const.py
+++ b/custom_components/watchman/utils/parser_const.py
@@ -59,3 +59,9 @@ CONFIG_ENTRY_DOMAINS = {'group', 'template'}
 
 # Directories to skip during recursive scan
 IGNORED_DIRS = {'.git', '__pycache__', '.venv', 'venv', 'deps', 'backups', 'custom_components', '.cache', '.esphome', '.storage', 'tmp', 'blueprints', 'media', 'share', 'www', 'trash'}
+
+# Regex building blocks for entity detection
+# Forbidden prefixes: letters, numbers, _, ., /, \, @, $, %, &, |, -
+REGEX_ENTITY_BOUNDARY = r"(?:^|[^a-zA-Z0-9_./\\@$%&|-])"
+REGEX_OPTIONAL_STATES = r"(?:states\.)?"
+REGEX_ENTITY_SUFFIX = r"\.[a-z0-9_]+"

--- a/tests/tests/test_regex_custom_domain_regression.py
+++ b/tests/tests/test_regex_custom_domain_regression.py
@@ -1,0 +1,37 @@
+import pytest
+import os
+from pathlib import Path
+from custom_components.watchman.utils.parser_core import WatchmanParser
+
+@pytest.mark.asyncio
+async def test_regex_false_positive_with_custom_domains(tmp_path):
+    """
+    Test that false positives like image paths are not detected as entities
+    when custom_domains are provided to async_scan.
+    """
+    # 1. Setup: Create a temporary configuration file with a false positive
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    test_file = config_dir / "test_config.yaml"
+    # This string should NOT be detected as sensor.png
+    test_file.write_text("image: /local/vacume/sensor.png", encoding="utf-8")
+    
+    db_path = str(tmp_path / "watchman.db")
+    parser = WatchmanParser(db_path)
+    
+    # 2. Execute: Scan with custom_domains provided
+    # This triggers the problematic re.compile in async_scan
+    await parser.async_scan(
+        root_path=str(config_dir),
+        ignored_files=[],
+        custom_domains=["sensor"]
+    )
+    
+    # 3. Verify: Check found items in the database
+    found_items = parser.get_found_items(item_type="entity")
+    
+    # Assert that no entities were found. 
+    # If the bug exists, it will find "sensor.png" because "/" is not in the exclusion group.
+    entities = [item[0] for item in found_items]
+    assert "sensor.png" not in entities
+    assert len(entities) == 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR addresses a regression in entity detection when `custom_domains` are used and refactors the regex logic to adhere to the Separation of Concerns principle. Closes #256.

**Changes:**

1. **Fix `async_scan` Logic:** Updated the `async_scan` method in `parser_core.py`. It previously used a hardcoded, outdated regex pattern when `custom_domains` were provided, ignoring the recently added forbidden prefixes (like `/`, `-`, `|`). It now uses the shared factory method `_compile_entity_pattern` to ensure consistency.
2. **Refactor Regex Constants:** Moved the regex building blocks (`REGEX_ENTITY_BOUNDARY`, `REGEX_OPTIONAL_STATES`, `REGEX_ENTITY_SUFFIX`) from `parser_core.py` to `parser_const.py`.
3. **Public API:** Renamed these constants (removed leading underscores) to expose them as part of the `parser_const`public API, allowing them to be imported and reused.

## Motivation and Context

**The Bug:**

While the global `_ENTITY_PATTERN` was correctly updated to exclude false positives (like filenames `image.png` or CSS classes), the `async_scan` function contained a duplicated, hardcoded regex generation logic for **custom domains**. This "shadow" logic was outdated and caused false positives to reappear when specific domains were passed to the parser (e.g., matching `/local/vacume/sensor.png` as `sensor.png` because the `/` prefix was not forbidden in the hardcoded version). **Custom domains** are the list of integration domains obtained from hass in runtime. It is unique for each HA installation.

**The Refactor:**

To prevent this divergence in the future and clean up `parser_core.py`:

- one applied the **DRY (Don't Repeat Yourself)** principle by enforcing a single factory method for regex compilation.
- one applied **Separation of Concerns** by moving static regex definitions to `parser_const.py`. This ensures `parser_core.py` focuses solely on parsing logic, while `parser_const.py` remains the Single Source of Truth for configuration and static data.

## How has this been tested?

Existing tests passed, new regression tests added.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
