### PR TITLE
fix: parse lovelace files regardless of their naming convention

### DIFF
--- a/custom_components/watchman/utils/parser_const.py
+++ b/custom_components/watchman/utils/parser_const.py
@@ -6,7 +6,8 @@ YAML_FILE_EXTS = {'.yaml', '.yml'}
 JSON_FILE_EXTS = {'.config_entries'}
 
 # For MVP, .storage is ignored completely if in _IGNORED_DIRS
-STORAGE_WHITELIST = {'lovelace', 'lovelace_dashboards', 'lovelace_resources', 'core.config_entries'}
+# Lovelace files (lovelace*) are detected dynamically by the parser
+STORAGE_WHITELIST = {'core.config_entries'}
 MAX_FILE_SIZE = 500 * 1024  # 500 KB
 
 # A fallback list of Home Assistant entity platforms for the CLI parser.

--- a/tests/data/.storage/core.config_entries
+++ b/tests/data/.storage/core.config_entries
@@ -1,0 +1,38 @@
+{
+    "data": {
+        "entries": [
+            {
+                "entry_id": "entry_1",
+                "domain": "group",
+                "title": "Kitchen Group",
+                "data": {
+                    "entities": ["light.kitchen_ceiling"]
+                }
+            },
+            {
+                "entry_id": "entry_2",
+                "domain": "template",
+                "title": "Garage Template",
+                "options": {
+                    "template_data": "{{ is_state('binary_sensor.garage_door', 'on') }}"
+                }
+            },
+            {
+                "entry_id": "entry_3",
+                "domain": "hassio",
+                "title": "Supervisor",
+                "data": {
+                    "some_config": "sensor.fake_sensor"
+                }
+            },
+            {
+                "entry_id": "entry_4",
+                "domain": "system",
+                "title": "System",
+                "data": {
+                    "info": "sensor.another_fake"
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/.storage/junk_file
+++ b/tests/data/.storage/junk_file
@@ -1,0 +1,3 @@
+{
+  "entity": "sensor.junk_no_ext"
+}

--- a/tests/data/.storage/junk_file.json
+++ b/tests/data/.storage/junk_file.json
@@ -1,0 +1,3 @@
+{
+  "entity": "sensor.junk_sensor"
+}

--- a/tests/data/.storage/junk_file.yaml
+++ b/tests/data/.storage/junk_file.yaml
@@ -1,0 +1,1 @@
+junk_entity: sensor.junk_yaml

--- a/tests/data/.storage/lovelace
+++ b/tests/data/.storage/lovelace
@@ -1,0 +1,19 @@
+{
+  "key": "lovelace",
+  "data": {
+    "config": {
+      "views": [
+        {
+          "cards": [
+            {
+              "type": "glance",
+              "entities": [
+                "sensor.test_main"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/data/.storage/lovelace.dashboard_test
+++ b/tests/data/.storage/lovelace.dashboard_test
@@ -1,0 +1,13 @@
+{
+  "title": "Test Dashboard",
+  "views": [
+    {
+      "cards": [
+        {
+          "type": "entity",
+          "entity": "sensor.test_new"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/.storage/lovelace_dashboards
+++ b/tests/data/.storage/lovelace_dashboards
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "items": [
+      {
+        "id": "legacy_dash",
+        "mode": "storage",
+        "icon": "mdi:monitor-dashboard",
+        "title": "Legacy Dashboard",
+        "require_admin": false,
+        "show_in_sidebar": true,
+        "url_path": "legacy-dashboard",
+        "config": {
+             "views": [
+                 {
+                     "cards": [
+                         {
+                             "entity": "sensor.test_legacy"
+                         }
+                     ]
+                 }
+             ]
+        }
+      }
+    ]
+  }
+}

--- a/tests/tests/test_lovelace_discovery.py
+++ b/tests/tests/test_lovelace_discovery.py
@@ -1,0 +1,42 @@
+"""Tests for Lovelace dashboard discovery in .storage."""
+import shutil
+from pathlib import Path
+import pytest
+from custom_components.watchman.utils.parser_core import WatchmanParser
+
+@pytest.fixture
+def parser_client(tmp_path):
+    """Create a WatchmanParser instance with a temporary database."""
+    db_path = tmp_path / "watchman.db"
+    client = WatchmanParser(str(db_path))
+    return client
+
+@pytest.mark.asyncio
+async def test_lovelace_dynamic_discovery(parser_client, tmp_path):
+    """Test that lovelace* files and core.config_entries in .storage are discovered, and junk is ignored."""
+    
+    # 1. Setup .storage directory in tmp_path
+    storage_dir = tmp_path / ".storage"
+    storage_dir.mkdir()
+    
+    # 2. Copy ALL files from tests/data/.storage to tmp_path/.storage
+    source_dir = Path("tests/data/.storage")
+    for file_path in source_dir.iterdir():
+        if file_path.is_file():
+            shutil.copy(file_path, storage_dir / file_path.name)
+    
+    # 3. Run Parser on the tmp_path
+    parsed_entities, _, _, _, _, _ = await parser_client.async_parse(str(tmp_path), [])
+    
+    # 4. Assertions for Lovelace Files (Dynamic Discovery)
+    assert "sensor.test_main" in parsed_entities, "Should find entity in 'lovelace'"
+    assert "sensor.test_legacy" in parsed_entities, "Should find entity in 'lovelace_dashboards'"
+    assert "sensor.test_new" in parsed_entities, "Should find entity in 'lovelace.dashboard_test'"
+    
+    # 5. Assertions for Whitelisted Files
+    assert "light.kitchen_ceiling" in parsed_entities, "Should find entity in 'core.config_entries'"
+    
+    # 6. Assertions for Junk Files (Should be Ignored)
+    assert "sensor.junk_sensor" not in parsed_entities, "Should NOT find entity in 'junk_file.json'"
+    assert "sensor.junk_no_ext" not in parsed_entities, "Should NOT find entity in 'junk_file'"
+    assert "sensor.junk_yaml" not in parsed_entities, "Should NOT find entity in 'junk_file.yaml'"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR overhauls the file scanning and type detection logic for the `.storage` directory to dynamically discover **all** Lovelace-related configuration files, regardless of their naming convention (dot-notation or underscore). Closes #260.

Key changes include:

- **Broadened Discovery Logic:** Updated `_scan_files_sync` and `_detect_file_type` to match any file starting with the prefix `lovelace` (e.g., `lovelace`, `lovelace.dashboard_utility`, `lovelace_dashboards`). Previously, the logic was too restrictive (whitelist-only) or risked being too narrow (dot-prefix only).
- **Constants Cleanup:** Removed `lovelace`, `lovelace_dashboards`, and `lovelace_resources` from `STORAGE_WHITELIST` in `parser_const.py`. These are now automatically caught by the new dynamic prefix logic, reducing maintenance effort. `STORAGE_WHITELIST` is now reserved strictly for files requiring exact matches (like `core.config_entries`).
- **Refactoring:** Removed the unused `_async_scan_files_legacy` method to clean up technical debt.


## Motivation and Context

**Problem:**

Users reported that the Watchman parser was ignoring valid Lovelace dashboard files in `/config/.storage/` if their filenames did not exactly match the static `STORAGE_WHITELIST`. Specifically, dynamically named files like `lovelace.dashboard_utility` were skipped, causing false positive "missing entity" reports.

**Solution:**
We switched from a static whitelist to a **prefix-based discovery strategy**.

By checking for `filename.startswith("lovelace")` (instead of the previously proposed `lovelace.`), we ensure complete coverage:

1. **New format:** `lovelace.dashboard_id` (fixes the reported issue).
2. **Legacy/System format:** `lovelace_dashboards` and `lovelace_resources` (preserves backward compatibility).
3. **Root config:** `lovelace` (preserves the main dashboard).

This change allows us to deprecate the manual maintenance of Lovelace filenames in the whitelist while ensuring no files are accidentally excluded.

## How has this been tested?

Added regression tests in `tests/test_lovelace_discovery.py` using standard test data to verify that the parser correctly identifies entities in:
    - Standard files (`lovelace`)
    - Legacy registry files (`lovelace_dashboards`)
    - New dashboard files (`lovelace.dashboard_utility`)

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
