### PR TITLE
test: Fix flaky tests and lingering timers due to improper teardown

### DIFF
--- a/tests/tests/test_action_state_change.py
+++ b/tests/tests/test_action_state_change.py
@@ -26,7 +26,7 @@ async def test_action_state_change_tracking(hass, tmp_path):
     config_file.write_text("automation:\n  - action:\n      - service: script.test_service", encoding="utf-8")
 
     # Initialize integration pointing to our temp config
-    await async_init_integration(
+    config_entry = await async_init_integration(
         hass,
         add_params={
             CONF_INCLUDED_FOLDERS: str(config_dir),
@@ -34,46 +34,50 @@ async def test_action_state_change_tracking(hass, tmp_path):
         },
     )
 
-    # Allow initial scan to complete
-    await hass.async_block_till_done()
+    try:
+        # Allow initial scan to complete
+        await hass.async_block_till_done()
 
-    # 2. Verify Initial State
-    # The service 'script.test_service' is NOT registered yet, so it should be reported as missing.
-    # Note: New installations use watchman_missing_actions by default
+        # 2. Verify Initial State
+        # The service 'script.test_service' is NOT registered yet, so it should be reported as missing.
+        # Note: New installations use watchman_missing_actions by default
 
-    from homeassistant.helpers import entity_registry as er
-    entity_registry = er.async_get(hass)
-    entity_id = next(e.entity_id for e in entity_registry.entities.values() if e.unique_id.endswith(SENSOR_MISSING_ACTIONS))
+        from homeassistant.helpers import entity_registry as er
+        entity_registry = er.async_get(hass)
+        entity_id = next(e.entity_id for e in entity_registry.entities.values() if e.unique_id.endswith(SENSOR_MISSING_ACTIONS))
 
-    missing_sensor = hass.states.get(entity_id)
-    assert missing_sensor is not None
-    assert missing_sensor.state == "1", "Initial missing count should be 1 (service not registered)"
-    assert "script.test_service" in str(missing_sensor.attributes)
+        missing_sensor = hass.states.get(entity_id)
+        assert missing_sensor is not None
+        assert missing_sensor.state == "1", "Initial missing count should be 1 (service not registered)"
+        assert "script.test_service" in str(missing_sensor.attributes)
 
-    # 3. Trigger: Register the service
-    def mock_service_handler(call):
-        pass
+        # 3. Trigger: Register the service
+        def mock_service_handler(call):
+            pass
 
-    hass.services.async_register("script", "test_service", mock_service_handler)
+        hass.services.async_register("script", "test_service", mock_service_handler)
 
-    # Allow event processing and debounced refresh (10s default cooldown)
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=11))
-    await hass.async_block_till_done()
+        # Allow event processing and debounced refresh (10s default cooldown)
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=11))
+        await hass.async_block_till_done()
 
-    # 4. Verify Updated State
-    # Watchman should detect the service registration and update counter to 0
-    missing_sensor = hass.states.get(f"sensor.{DOMAIN}_{SENSOR_MISSING_ACTIONS}")
-    assert missing_sensor.state == "0", "Missing count should update to 0 after service is registered"
+        # 4. Verify Updated State
+        # Watchman should detect the service registration and update counter to 0
+        missing_sensor = hass.states.get(f"sensor.{DOMAIN}_{SENSOR_MISSING_ACTIONS}")
+        assert missing_sensor.state == "0", "Missing count should update to 0 after service is registered"
 
-    # 5. Trigger: Remove the service
-    hass.services.async_remove("script", "test_service")
+        # 5. Trigger: Remove the service
+        hass.services.async_remove("script", "test_service")
 
-    # Allow event processing and debounced refresh
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=11))
-    await hass.async_block_till_done()
+        # Allow event processing and debounced refresh
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=11))
+        await hass.async_block_till_done()
 
-    # 6. Verify Final State
-    # Watchman should detect service removal and increment counter back to 1
-    missing_sensor = hass.states.get(f"sensor.{DOMAIN}_{SENSOR_MISSING_ACTIONS}")
-    assert missing_sensor.state == "1", "Missing count should return to 1 after service is removed"
-    assert "script.test_service" in str(missing_sensor.attributes)
+        # 6. Verify Final State
+        # Watchman should detect service removal and increment counter back to 1
+        missing_sensor = hass.states.get(f"sensor.{DOMAIN}_{SENSOR_MISSING_ACTIONS}")
+        assert missing_sensor.state == "1", "Missing count should return to 1 after service is removed"
+        assert "script.test_service" in str(missing_sensor.attributes)
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/tests/test_button.py
+++ b/tests/tests/test_button.py
@@ -12,49 +12,53 @@ from homeassistant.setup import async_setup_component
 async def test_button_press_triggers_report(hass: HomeAssistant):
     """Test that pressing the button triggers the report service."""
     await async_setup_component(hass, "persistent_notification", {})
-    await async_init_integration(hass)
+    config_entry = await async_init_integration(hass)
 
-    # Verify button entity exists
-    entity_registry = er.async_get(hass)
-    entry = entity_registry.async_get("button.watchman_create_report_file")
-    assert entry
-    assert entry.platform == DOMAIN
+    try:
+        # Verify button entity exists
+        entity_registry = er.async_get(hass)
+        entry = entity_registry.async_get("button.watchman_create_report_file")
+        assert entry
+        assert entry.platform == DOMAIN
 
-    # Patch the service call to verify it's called
-    # Also patch async_report_to_file to prevent actual file writing failure (due to empty path in defaults)
-    # And patch button.get_config so notification gets a path
-    with patch(
-        "homeassistant.core.ServiceRegistry.async_call",
-        wraps=hass.services.async_call
-    ) as mock_service_call, \
-         patch("custom_components.watchman.services.async_report_to_file") as mock_write_file, \
-         patch("custom_components.watchman.button.get_config", return_value="/tmp/report.txt"):
+        # Patch the service call to verify it's called
+        # Also patch async_report_to_file to prevent actual file writing failure (due to empty path in defaults)
+        # And patch button.get_config so notification gets a path
+        with patch(
+            "homeassistant.core.ServiceRegistry.async_call",
+            wraps=hass.services.async_call
+        ) as mock_service_call, \
+             patch("custom_components.watchman.services.async_report_to_file") as mock_write_file, \
+             patch("custom_components.watchman.button.get_config", return_value="/tmp/report.txt"):
 
-        # Press the button
-        await hass.services.async_call(
-            "button", "press", {"entity_id": "button.watchman_create_report_file"}, blocking=True
-        )
+            # Press the button
+            await hass.services.async_call(
+                "button", "press", {"entity_id": "button.watchman_create_report_file"}, blocking=True
+            )
+            await hass.async_block_till_done()
+
+            # Verify watchman.report was called with correct parameters
+            # mock_service_call captures all service calls.
+
+            found_call = False
+            found_notify = False
+
+            for call in mock_service_call.mock_calls:
+                domain = call.args[0] if call.args else call.kwargs.get('domain')
+                service = call.args[1] if len(call.args) > 1 else call.kwargs.get('service')
+
+                if domain == DOMAIN and service == REPORT_SERVICE_NAME:
+                    service_data = call.args[2] if len(call.args) > 2 else call.kwargs.get('service_data')
+                    if service_data == {"parse_config": True}:
+                        found_call = True
+
+                if domain == "persistent_notification" and service == "create":
+                    service_data = call.args[2] if len(call.args) > 2 else call.kwargs.get('service_data')
+                    if service_data and service_data.get("title") == "🛡️Watchman":
+                        found_notify = True
+
+            assert found_call, "watchman.report service was not called with parse_config=True"
+            assert found_notify, "persistent_notification.create was not called with title='🛡️Watchman'"
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
-
-        # Verify watchman.report was called with correct parameters
-        # mock_service_call captures all service calls.
-
-        found_call = False
-        found_notify = False
-
-        for call in mock_service_call.mock_calls:
-            domain = call.args[0] if call.args else call.kwargs.get('domain')
-            service = call.args[1] if len(call.args) > 1 else call.kwargs.get('service')
-
-            if domain == DOMAIN and service == REPORT_SERVICE_NAME:
-                service_data = call.args[2] if len(call.args) > 2 else call.kwargs.get('service_data')
-                if service_data == {"parse_config": True}:
-                    found_call = True
-
-            if domain == "persistent_notification" and service == "create":
-                service_data = call.args[2] if len(call.args) > 2 else call.kwargs.get('service_data')
-                if service_data and service_data.get("title") == "🛡️Watchman":
-                    found_notify = True
-
-        assert found_call, "watchman.report service was not called with parse_config=True"
-        assert found_notify, "persistent_notification.create was not called with title='🛡️Watchman'"

--- a/tests/tests/test_coordinator_cache.py
+++ b/tests/tests/test_coordinator_cache.py
@@ -18,71 +18,79 @@ from tests import async_init_integration
 async def test_filter_context_cache_hit(hass):
     """Test that _build_filter_context is only called once when cache is valid."""
     config_entry = await async_init_integration(hass)
-    coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    try:
+        coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    # Force clear cache first (it was built during init)
-    coordinator.invalidate_filter_context()
-    assert coordinator._filter_context_cache is None
+        # Force clear cache first (it was built during init)
+        coordinator.invalidate_filter_context()
+        assert coordinator._filter_context_cache is None
 
-    # Call 1: Should build
-    ctx1 = coordinator._build_filter_context()
-    assert ctx1 is not None
-    assert coordinator._filter_context_cache is ctx1
+        # Call 1: Should build
+        ctx1 = coordinator._build_filter_context()
+        assert ctx1 is not None
+        assert coordinator._filter_context_cache is ctx1
 
-    # Call 2: Should return cached object
-    # We patch er.async_get to ensure it's NOT called, proving we didn't rebuild
-    with patch("homeassistant.helpers.entity_registry.async_get", side_effect=AssertionError("Should not access registry on cache hit")) as mock_er:
-        ctx2 = coordinator._build_filter_context()
-        assert ctx2 is ctx1
+        # Call 2: Should return cached object
+        # We patch er.async_get to ensure it's NOT called, proving we didn't rebuild
+        with patch("homeassistant.helpers.entity_registry.async_get", side_effect=AssertionError("Should not access registry on cache hit")) as mock_er:
+            ctx2 = coordinator._build_filter_context()
+            assert ctx2 is ctx1
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
 
 
 @pytest.mark.asyncio
 async def test_event_storm_debouncing(hass):
     """Test that an event storm only triggers one cache rebuild/refresh."""
     config_entry = await async_init_integration(hass)
-    coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-    
-    # 1. Setup Automations in State Machine so we can track them
-    for i in range(10):
-        hass.states.async_set(f"automation.test_{i}", "off")
+    try:
+        coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
         
-    # 2. Trigger listener update (e.g. reload or registry update)
-    # We call internal method to force update for test setup
-    coordinator._update_automation_listener()
-    
-    # Spy on _build_filter_context
-    # We need to wrap it on the instance
-    with patch.object(coordinator, "_build_filter_context", wraps=coordinator._build_filter_context) as mock_build:
-        
-        # Fire storm
-        # 10 State Changes
+        # 1. Setup Automations in State Machine so we can track them
         for i in range(10):
-            # We must use async_set to trigger state_changed event properly for async_track...
-            # Or async_fire(EVENT_STATE_CHANGED) if we construct payload carefully.
-            # async_track_state_change_event uses "state_changed" event.
-            # But it checks entity_id match.
-            hass.bus.async_fire(EVENT_STATE_CHANGED, {
-                "entity_id": f"automation.test_{i}",
-                "old_state": MagicMock(state="off"),
-                "new_state": MagicMock(state="on")
+            hass.states.async_set(f"automation.test_{i}", "off")
+            
+        # 2. Trigger listener update (e.g. reload or registry update)
+        # We call internal method to force update for test setup
+        coordinator._update_automation_listener()
+        
+        # Spy on _build_filter_context
+        # We need to wrap it on the instance
+        with patch.object(coordinator, "_build_filter_context", wraps=coordinator._build_filter_context) as mock_build:
+            
+            # Fire storm
+            # 10 State Changes
+            for i in range(10):
+                # We must use async_set to trigger state_changed event properly for async_track...
+                # Or async_fire(EVENT_STATE_CHANGED) if we construct payload carefully.
+                # async_track_state_change_event uses "state_changed" event.
+                # But it checks entity_id match.
+                hass.bus.async_fire(EVENT_STATE_CHANGED, {
+                    "entity_id": f"automation.test_{i}",
+                    "old_state": MagicMock(state="off"),
+                    "new_state": MagicMock(state="on")
+                })
+            
+            # 1 Registry Update
+            hass.bus.async_fire(EVENT_ENTITY_REGISTRY_UPDATED, {
+                "action": "update",
+                "entity_id": "automation.test_reg",
+                "changes": {}
             })
-        
-        # 1 Registry Update
-        hass.bus.async_fire(EVENT_ENTITY_REGISTRY_UPDATED, {
-            "action": "update",
-            "entity_id": "automation.test_reg",
-            "changes": {}
-        })
-        
-        await hass.async_block_till_done()
+            
+            await hass.async_block_till_done()
 
-        # In test env, Debouncer might run immediately or coalesced.
-        # We verify that it ran AT MOST once for the whole storm (proving coalescing)
-        # instead of verifying it hasn't run yet (which depends on strict timing)
-        assert mock_build.call_count == 1
-        
-        # Since it ran, cache is populated
-        assert coordinator._filter_context_cache is not None
+            # In test env, Debouncer might run immediately or coalesced.
+            # We verify that it ran AT MOST once for the whole storm (proving coalescing)
+            # instead of verifying it hasn't run yet (which depends on strict timing)
+            assert mock_build.call_count == 1
+            
+            # Since it ran, cache is populated
+            assert coordinator._filter_context_cache is not None
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
 
 
 @pytest.mark.asyncio
@@ -97,38 +105,42 @@ async def test_startup_safety(hass):
     # Instead, let's verify that the coordinator HAS subscriptions after startup.
     
     config_entry = await async_init_integration(hass)
-    coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-    
-    # Verify we have listeners. 
-    # hass.bus._listeners is internal, but we can verify behavior.
-    # firing an event should trigger the coordinator.
-    
-    with patch.object(coordinator, "request_parser_rescan") as mock_rescan:
+    try:
+        coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+        
+        # Verify we have listeners. 
+        # hass.bus._listeners is internal, but we can verify behavior.
+        # firing an event should trigger the coordinator.
+        
+        with patch.object(coordinator, "request_parser_rescan") as mock_rescan:
+            hass.bus.async_fire(EVENT_ENTITY_REGISTRY_UPDATED, {
+                "action": "create",
+                "entity_id": "automation.new_auto"
+            })
+            await hass.async_block_till_done()
+            
+            # Should trigger refresh (which calls rescan eventually if needed? No, async_request_refresh updates sensors)
+            # But wait, async_on_registry_updated calls async_request_refresh.
+            # This calls _async_update_data -> async_process_parsed_data -> _build_filter_context.
+            # It does NOT call request_parser_rescan unless configured?
+            # Actually, async_request_refresh just refreshes data.
+            pass
+
+        # Verify invalidation happens
+        # We set it to a Mock. If it's invalidated and rebuilt, it will be a real FilterContext
+        fake_ctx = MagicMock()
+        coordinator._filter_context_cache = fake_ctx
         hass.bus.async_fire(EVENT_ENTITY_REGISTRY_UPDATED, {
-            "action": "create",
-            "entity_id": "automation.new_auto"
+            "action": "update",
+            "entity_id": "automation.existing",
+            "changes": {}
         })
         await hass.async_block_till_done()
         
-        # Should trigger refresh (which calls rescan eventually if needed? No, async_request_refresh updates sensors)
-        # But wait, async_on_registry_updated calls async_request_refresh.
-        # This calls _async_update_data -> async_process_parsed_data -> _build_filter_context.
-        # It does NOT call request_parser_rescan unless configured?
-        # Actually, async_request_refresh just refreshes data.
-        pass
-
-    # Verify invalidation happens
-    # We set it to a Mock. If it's invalidated and rebuilt, it will be a real FilterContext
-    fake_ctx = MagicMock()
-    coordinator._filter_context_cache = fake_ctx
-    hass.bus.async_fire(EVENT_ENTITY_REGISTRY_UPDATED, {
-        "action": "update",
-        "entity_id": "automation.existing",
-        "changes": {}
-    })
-    await hass.async_block_till_done()
-    
-    # It should have been invalidated (set to None) and then rebuilt (set to FilterContext)
-    # So it should NOT be the fake_ctx anymore
-    assert coordinator._filter_context_cache is not fake_ctx
-    assert coordinator._filter_context_cache is not None
+        # It should have been invalidated (set to None) and then rebuilt (set to FilterContext)
+        # So it should NOT be the fake_ctx anymore
+        assert coordinator._filter_context_cache is not fake_ctx
+        assert coordinator._filter_context_cache is not None
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/tests/test_coordinator_delay.py
+++ b/tests/tests/test_coordinator_delay.py
@@ -24,117 +24,129 @@ def mock_hub_parse():
 async def test_debounce_rescan(hass: HomeAssistant, mock_hub_parse):
     """Test that multiple rescan requests are debounced."""
     config_entry = await async_init_integration(hass)
-    coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    try:
+        coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    # Reset mock and coordinator state
-    mock_hub_parse.reset_mock()
-    if coordinator.safe_mode:
-        coordinator.update_status(STATE_IDLE)
-    coordinator._last_parse_time = 0 # Ensure no cooldown issues for this test
+        # Reset mock and coordinator state
+        mock_hub_parse.reset_mock()
+        if coordinator.safe_mode:
+            coordinator.update_status(STATE_IDLE)
+        coordinator._last_parse_time = 0 # Ensure no cooldown issues for this test
 
-    # 1. Request rescan with delay
-    coordinator.request_parser_rescan(reason="test1", delay=2)
-    assert coordinator._delay_unsub is not None
-    assert coordinator.status == STATE_PENDING
+        # 1. Request rescan with delay
+        coordinator.request_parser_rescan(reason="test1", delay=2)
+        assert coordinator._delay_unsub is not None
+        assert coordinator.status == STATE_PENDING
 
-    # 2. Advance time by 1s (halfway)
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=1))
-    await hass.async_block_till_done()
+        # 2. Advance time by 1s (halfway)
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=1))
+        await hass.async_block_till_done()
 
-    # Verify not parsed yet
-    mock_hub_parse.assert_not_called()
+        # Verify not parsed yet
+        mock_hub_parse.assert_not_called()
 
-    # 3. Request rescan again (should reset timer)
-    coordinator.request_parser_rescan(reason="test2", delay=2)
+        # 3. Request rescan again (should reset timer)
+        coordinator.request_parser_rescan(reason="test2", delay=2)
 
-    # 4. Advance time by 1.5s (original timer would have fired at 2.0s, now at 1.0+1.5=2.5s)
-    # Total time from start: 2.5s.
-    # First request was at T=0. Second at T=1.
-    # If first request was active, it would fire at T=2.
-    # Since we reset at T=1 with delay=2, it should fire at T=3.
+        # 4. Advance time by 1.5s (original timer would have fired at 2.0s, now at 1.0+1.5=2.5s)
+        # Total time from start: 2.5s.
+        # First request was at T=0. Second at T=1.
+        # If first request was active, it would fire at T=2.
+        # Since we reset at T=1 with delay=2, it should fire at T=3.
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=1.5))
-    await hass.async_block_till_done()
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=1.5))
+        await hass.async_block_till_done()
 
-    # Should still not be called (T=2.5 < T=3)
-    mock_hub_parse.assert_not_called()
+        # Should still not be called (T=2.5 < T=3)
+        mock_hub_parse.assert_not_called()
 
-    # 5. Advance time to T=3.1
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=0.6))
-    await hass.async_block_till_done()
+        # 5. Advance time to T=3.1
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=0.6))
+        await hass.async_block_till_done()
 
-    # Should be called now
-    await hass.async_block_till_done()
-    import asyncio
-    await asyncio.sleep(0.1)
-    mock_hub_parse.assert_called_once()
+        # Should be called now
+        await hass.async_block_till_done()
+        import asyncio
+        await asyncio.sleep(0.1)
+        mock_hub_parse.assert_called_once()
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
 
 
 async def test_force_rescan(hass: HomeAssistant, mock_hub_parse):
     """Test that force=True bypasses delay."""
     config_entry = await async_init_integration(hass)
-    coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    try:
+        coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    mock_hub_parse.reset_mock()
-    if coordinator.safe_mode:
-        coordinator.update_status(STATE_IDLE)
-    coordinator._last_parse_time = 0
+        mock_hub_parse.reset_mock()
+        if coordinator.safe_mode:
+            coordinator.update_status(STATE_IDLE)
+        coordinator._last_parse_time = 0
 
-    # 1. Request rescan with delay
-    coordinator.request_parser_rescan(reason="test_delay", delay=5)
-    assert coordinator._delay_unsub is not None
+        # 1. Request rescan with delay
+        coordinator.request_parser_rescan(reason="test_delay", delay=5)
+        assert coordinator._delay_unsub is not None
 
-    # 2. Immediately force rescan
-    coordinator.request_parser_rescan(reason="test_force", force=True)
+        # 2. Immediately force rescan
+        coordinator.request_parser_rescan(reason="test_force", force=True)
 
-    assert coordinator._delay_unsub is None
-    # Wait for background task
-    await hass.async_block_till_done()
-    import asyncio
-    for _ in range(5):
-        if mock_hub_parse.call_count == 1:
-            break
-        await asyncio.sleep(0.1)
+        assert coordinator._delay_unsub is None
+        # Wait for background task
+        await hass.async_block_till_done()
+        import asyncio
+        for _ in range(5):
+            if mock_hub_parse.call_count == 1:
+                break
+            await asyncio.sleep(0.1)
 
-    mock_hub_parse.assert_called_once()
+        mock_hub_parse.assert_called_once()
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
 
 async def test_force_rescan_during_cooldown(hass: HomeAssistant, mock_hub_parse):
     """Test that force=True correctly cancels a pending cooldown timer."""
     config_entry = await async_init_integration(hass)
-    coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    try:
+        coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    mock_hub_parse.reset_mock()
-    if coordinator.safe_mode:
-        coordinator.update_status(STATE_IDLE)
+        mock_hub_parse.reset_mock()
+        if coordinator.safe_mode:
+            coordinator.update_status(STATE_IDLE)
 
-    # 1. Simulate a completed parse recently
-    coordinator._last_parse_time = time.time()
+        # 1. Simulate a completed parse recently
+        coordinator._last_parse_time = time.time()
 
-    # 2. Request rescan. It should hit cooldown logic.
-    coordinator.request_parser_rescan(reason="test_trigger_cooldown", delay=1)
+        # 2. Request rescan. It should hit cooldown logic.
+        coordinator.request_parser_rescan(reason="test_trigger_cooldown", delay=1)
 
-    # Advance time to expire the delay (1s) so it moves to cooldown state
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=1.1))
-    await hass.async_block_till_done()
+        # Advance time to expire the delay (1s) so it moves to cooldown state
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=1.1))
+        await hass.async_block_till_done()
 
-    # Cooldown timer should be active now
-    assert coordinator._cooldown_unsub is not None
-    assert coordinator.status == STATE_PENDING
+        # Cooldown timer should be active now
+        assert coordinator._cooldown_unsub is not None
+        assert coordinator.status == STATE_PENDING
 
-    # 3. Request force rescan. This should CANCEL the cooldown timer.
-    # If the bug exists (trying to call the handle), this will raise TypeError.
-    coordinator.request_parser_rescan(reason="test_force_cooldown", force=True)
+        # 3. Request force rescan. This should CANCEL the cooldown timer.
+        # If the bug exists (trying to call the handle), this will raise TypeError.
+        coordinator.request_parser_rescan(reason="test_force_cooldown", force=True)
 
-    assert coordinator._cooldown_unsub is None
-    await hass.async_block_till_done()
+        assert coordinator._cooldown_unsub is None
+        await hass.async_block_till_done()
 
-    import asyncio
-    for _ in range(5):
-        if mock_hub_parse.call_count == 1:
-            break
-        await asyncio.sleep(0.1)
+        import asyncio
+        for _ in range(5):
+            if mock_hub_parse.call_count == 1:
+                break
+            await asyncio.sleep(0.1)
 
-    mock_hub_parse.assert_called_once()
+        mock_hub_parse.assert_called_once()
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
 
 
 
@@ -142,49 +154,53 @@ async def test_force_rescan_during_cooldown(hass: HomeAssistant, mock_hub_parse)
 async def test_smart_debounce_priority(hass: HomeAssistant, mock_hub_parse):
     """Test that the longest delay takes precedence (Smart Debounce)."""
     config_entry = await async_init_integration(hass)
-    coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    try:
+        coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    mock_hub_parse.reset_mock()
-    if coordinator.safe_mode:
-        coordinator.update_status(STATE_IDLE)
-    coordinator._last_parse_time = 0
+        mock_hub_parse.reset_mock()
+        if coordinator.safe_mode:
+            coordinator.update_status(STATE_IDLE)
+        coordinator._last_parse_time = 0
 
-    # 1. Request rescan with LONG delay (e.g. startup)
-    long_delay = 10
-    coordinator.request_parser_rescan(reason="startup", delay=long_delay)
+        # 1. Request rescan with LONG delay (e.g. startup)
+        long_delay = 10
+        coordinator.request_parser_rescan(reason="startup", delay=long_delay)
 
-    # 2. Advance time slightly (e.g. 1s)
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=1))
-    await hass.async_block_till_done()
+        # 2. Advance time slightly (e.g. 1s)
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=1))
+        await hass.async_block_till_done()
 
-    # 3. Request rescan with SHORT delay (e.g. config change)
-    short_delay = 1
-    coordinator.request_parser_rescan(reason="config_change", delay=short_delay)
+        # 3. Request rescan with SHORT delay (e.g. config change)
+        short_delay = 1
+        coordinator.request_parser_rescan(reason="config_change", delay=short_delay)
 
-    # 4. Advance time by short_delay + buffer (e.g. +2s total from step 3)
-    # Total time from start = 1 + 2 = 3s.
-    # Current naive implementation would fire here (1s after step 3).
-    # Desired logic: Should NOT fire yet, because we should respect the 10s delay.
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=3))
-    await hass.async_block_till_done()
+        # 4. Advance time by short_delay + buffer (e.g. +2s total from step 3)
+        # Total time from start = 1 + 2 = 3s.
+        # Current naive implementation would fire here (1s after step 3).
+        # Desired logic: Should NOT fire yet, because we should respect the 10s delay.
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=3))
+        await hass.async_block_till_done()
 
-    # Assert NOT called yet
-    assert mock_hub_parse.call_count == 0
+        # Assert NOT called yet
+        assert mock_hub_parse.call_count == 0
 
-    # 5. Advance time to cover the full long_delay relative to the LAST request?
-    # Requirement: "отложить парсинг ещё на 10 секунд с момента регистрации второго запроса"
-    # So we need to wait 10s from step 3.
-    # We are at T=3s (relative to start). Step 3 happened at T=1s.
-    # We need to reach T = 1s + 10s = 11s.
-    # So advance by another 8s + buffer.
+        # 5. Advance time to cover the full long_delay relative to the LAST request?
+        # Requirement: "отложить парсинг ещё на 10 секунд с момента регистрации второго запроса"
+        # So we need to wait 10s from step 3.
+        # We are at T=3s (relative to start). Step 3 happened at T=1s.
+        # We need to reach T = 1s + 10s = 11s.
+        # So advance by another 8s + buffer.
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=12))
-    await hass.async_block_till_done()
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=12))
+        await hass.async_block_till_done()
 
-    import asyncio
-    for _ in range(5):
-        if mock_hub_parse.call_count == 1:
-            break
-        await asyncio.sleep(0.1)
+        import asyncio
+        for _ in range(5):
+            if mock_hub_parse.call_count == 1:
+                break
+            await asyncio.sleep(0.1)
 
-    mock_hub_parse.assert_called_once()
+        mock_hub_parse.assert_called_once()
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/tests/test_coordinator_optimization.py
+++ b/tests/tests/test_coordinator_optimization.py
@@ -19,30 +19,33 @@ async def test_incremental_update(hass, tmp_path):
     config_dir.mkdir()
     (config_dir / "test.yaml").write_text("sensor:\n  - platform: template\n    sensors:\n      test:\n        value_template: '{{ states.sensor.missing_one }}'", encoding="utf-8")
 
-    await async_init_integration(hass, add_params={CONF_INCLUDED_FOLDERS: str(config_dir)})
-    await hass.async_block_till_done()
-
-    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
-    coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-
-    # Verify initial state: 1 missing entity
-    assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 1
-    assert "sensor.missing_one" in coordinator._missing_entities_cache
-
-    # 2. Action: Change state to 'on' (Available)
-    # We patch renew_missing_items_list to ensure it is NOT called
-    with patch("custom_components.watchman.coordinator.renew_missing_items_list", side_effect=AssertionError("Should not call full scan")) as mock_renew:
-        hass.states.async_set("sensor.missing_one", "on")
-        
-        # Trigger debounce immediately
-        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
+    config_entry = await async_init_integration(hass, add_params={CONF_INCLUDED_FOLDERS: str(config_dir)})
+    try:
         await hass.async_block_till_done()
 
-        # 3. Assert
-        # Count should be 0
-        assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 0
-        assert "sensor.missing_one" not in coordinator._missing_entities_cache
-        # Mock verified call count
+        coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+        # Verify initial state: 1 missing entity
+        assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 1
+        assert "sensor.missing_one" in coordinator._missing_entities_cache
+
+        # 2. Action: Change state to 'on' (Available)
+        # We patch renew_missing_items_list to ensure it is NOT called
+        with patch("custom_components.watchman.coordinator.renew_missing_items_list", side_effect=AssertionError("Should not call full scan")) as mock_renew:
+            hass.states.async_set("sensor.missing_one", "on")
+            
+            # Trigger debounce immediately
+            async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
+            await hass.async_block_till_done()
+
+            # 3. Assert
+            # Count should be 0
+            assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 0
+            assert "sensor.missing_one" not in coordinator._missing_entities_cache
+            # Mock verified call count
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
 
 
 @pytest.mark.asyncio
@@ -55,59 +58,62 @@ async def test_interleaved_events(hass, tmp_path, caplog):
     config_dir.mkdir()
     (config_dir / "test.yaml").write_text("sensor:\n  - platform: template\n    sensors:\n      test:\n        value_template: '{{ states.sensor.test_race }}'", encoding="utf-8")
 
-    await async_init_integration(hass, add_params={CONF_INCLUDED_FOLDERS: str(config_dir)})
-    await hass.async_block_till_done()
-    
-    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
-    coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-
-    # Initial state: missing
-    assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 1
-
-    # 2. Action: Trigger State Change (Dirty Set) AND Automation Toggle (Full Rescan)
-    # Pause debouncer execution to queue both
-    
-    # a. Dirty Set event
-    hass.states.async_set("sensor.test_race", "on")
-    await hass.async_block_till_done()
-    
-    # b. Automation Toggle event (Global Context)
-    # We simulate automation state change
-    hass.states.async_set("automation.some_automation", "on")
-    
-    coordinator.invalidate_filter_context()
-    
-    # 3. Trigger Refresh
-    # We verify that renew_missing_items_list IS called (Full Path)
-    
-    import custom_components.watchman.coordinator as coord_module
-    original_renew = coord_module.renew_missing_items_list
-    
-    with patch("custom_components.watchman.coordinator.renew_missing_items_list", wraps=None) as mock_renew:
-        mock_renew.side_effect = original_renew
-
-        # Simulate the refresh request that usually accompanies context invalidation
-        await coordinator.async_request_refresh()
-        
-        # Ensure debouncer fires if delayed
-        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
+    config_entry = await async_init_integration(hass, add_params={CONF_INCLUDED_FOLDERS: str(config_dir)})
+    try:
         await hass.async_block_till_done()
+        
+        coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-        # Check result first to confirm update ran
-        assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 0, "Entities should be found (0 missing)"
+        # Initial state: missing
+        assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 1
+
+        # 2. Action: Trigger State Change (Dirty Set) AND Automation Toggle (Full Rescan)
+        # Pause debouncer execution to queue both
         
-        # Check logs for Full Rescan path
-        assert "performing FULL status check." in caplog.text
-        # Mock verification (optional if logs checked, but good double check)
-        assert mock_renew.called, "Full rescan SHOULD happen"
+        # a. Dirty Set event
+        hass.states.async_set("sensor.test_race", "on")
+        await hass.async_block_till_done()
         
-    # 4. Assert Final State
+        # b. Automation Toggle event (Global Context)
+        # We simulate automation state change
+        hass.states.async_set("automation.some_automation", "on")
         
-    # 4. Assert Final State
-    # Entity is ON, so it should NOT be missing.
-    # Full rescan should detect "on" state.
-    assert len(coordinator._dirty_entities) == 0
-    assert coordinator._force_full_rescan is False
+        coordinator.invalidate_filter_context()
+        
+        # 3. Trigger Refresh
+        # We verify that renew_missing_items_list IS called (Full Path)
+        
+        import custom_components.watchman.coordinator as coord_module
+        original_renew = coord_module.renew_missing_items_list
+        
+        with patch("custom_components.watchman.coordinator.renew_missing_items_list", wraps=None) as mock_renew:
+            mock_renew.side_effect = original_renew
+
+            # Simulate the refresh request that usually accompanies context invalidation
+            await coordinator.async_request_refresh()
+            
+            # Ensure debouncer fires if delayed
+            async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
+            await hass.async_block_till_done()
+
+            # Check result first to confirm update ran
+            assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 0, "Entities should be found (0 missing)"
+            
+            # Check logs for Full Rescan path
+            assert "performing FULL status check." in caplog.text
+            # Mock verification (optional if logs checked, but good double check)
+            assert mock_renew.called, "Full rescan SHOULD happen"
+            
+        # 4. Assert Final State
+            
+        # 4. Assert Final State
+        # Entity is ON, so it should NOT be missing.
+        # Full rescan should detect "on" state.
+        assert len(coordinator._dirty_entities) == 0
+        assert coordinator._force_full_rescan is False
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
 
 @pytest.mark.asyncio
 async def test_debounce_flip_flop(hass, tmp_path):
@@ -117,32 +123,35 @@ async def test_debounce_flip_flop(hass, tmp_path):
     config_dir.mkdir()
     (config_dir / "test.yaml").write_text("sensor:\n  - platform: template\n    sensors:\n      test:\n        value_template: '{{ states.sensor.flip_flop }}'", encoding="utf-8")
 
-    await async_init_integration(hass, add_params={CONF_INCLUDED_FOLDERS: str(config_dir)})
-    await hass.async_block_till_done()
-    
-    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
-    coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-    
-    # Initial: Missing
-    assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 1
-    
-    # 2. Flip Flop sequence
-    # Missing -> On -> Missing
-    
-    # a. On
-    hass.states.async_set("sensor.flip_flop", "on")
-    # b. Missing (Unavailable)
-    hass.states.async_set("sensor.flip_flop", "unavailable")
-    
-    # 3. Fire Debounce
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
-    await hass.async_block_till_done()
-    
-    # 4. Assert
-    # It should be missing
-    assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 1
-    # Verify we processed the dirty entity
-    assert "sensor.flip_flop" in coordinator._missing_entities_cache
+    config_entry = await async_init_integration(hass, add_params={CONF_INCLUDED_FOLDERS: str(config_dir)})
+    try:
+        await hass.async_block_till_done()
+        
+        coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+        
+        # Initial: Missing
+        assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 1
+        
+        # 2. Flip Flop sequence
+        # Missing -> On -> Missing
+        
+        # a. On
+        hass.states.async_set("sensor.flip_flop", "on")
+        # b. Missing (Unavailable)
+        hass.states.async_set("sensor.flip_flop", "unavailable")
+        
+        # 3. Fire Debounce
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
+        await hass.async_block_till_done()
+        
+        # 4. Assert
+        # It should be missing
+        assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 1
+        # Verify we processed the dirty entity
+        assert "sensor.flip_flop" in coordinator._missing_entities_cache
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
 
 
 @pytest.mark.asyncio
@@ -153,23 +162,26 @@ async def test_unknown_entity(hass, tmp_path):
     config_dir.mkdir()
     (config_dir / "test.yaml").write_text("sensor:\n  - platform: template\n    sensors:\n      test:\n        value_template: '{{ states.sensor.known }}'", encoding="utf-8")
 
-    await async_init_integration(hass, add_params={CONF_INCLUDED_FOLDERS: str(config_dir)})
-    await hass.async_block_till_done()
-    
-    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
-    coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-    
-    initial_missing = coordinator.data[COORD_DATA_MISSING_ENTITIES]
-    
-    # 2. Action: Fire event for unknown entity
-    # This adds it to _dirty_entities
-    hass.states.async_set("sensor.random_garbage", "on")
-    
-    # 3. Fire Debounce
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
-    await hass.async_block_till_done()
-    
-    # 4. Assert
-    assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == initial_missing
-    # Should not be in missing cache
-    assert "sensor.random_garbage" not in coordinator._missing_entities_cache
+    config_entry = await async_init_integration(hass, add_params={CONF_INCLUDED_FOLDERS: str(config_dir)})
+    try:
+        await hass.async_block_till_done()
+        
+        coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+        
+        initial_missing = coordinator.data[COORD_DATA_MISSING_ENTITIES]
+        
+        # 2. Action: Fire event for unknown entity
+        # This adds it to _dirty_entities
+        hass.states.async_set("sensor.random_garbage", "on")
+        
+        # 3. Fire Debounce
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
+        await hass.async_block_till_done()
+        
+        # 4. Assert
+        assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == initial_missing
+        # Should not be in missing cache
+        assert "sensor.random_garbage" not in coordinator._missing_entities_cache
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/tests/test_coordinator_stats_update.py
+++ b/tests/tests/test_coordinator_stats_update.py
@@ -15,35 +15,39 @@ from homeassistant.util import dt as dt_util
 async def test_async_save_stats_updates_memory(hass):
     """Test that async_save_stats updates the coordinator's in-memory data."""
     config_entry = await async_init_integration(hass)
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    try:
+        coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    # Reset data to ensure clean state
-    coordinator.data[COORD_DATA_PARSE_DURATION] = 0.0
-    coordinator.data[COORD_DATA_PROCESSED_FILES] = 0
+        # Reset data to ensure clean state
+        coordinator.data[COORD_DATA_PARSE_DURATION] = 0.0
+        coordinator.data[COORD_DATA_PROCESSED_FILES] = 0
 
-    # Initial state should be empty/zero
-    assert coordinator.data.get(COORD_DATA_PARSE_DURATION) == 0.0
-    assert coordinator.data.get(COORD_DATA_PROCESSED_FILES) == 0
+        # Initial state should be empty/zero
+        assert coordinator.data.get(COORD_DATA_PARSE_DURATION) == 0.0
+        assert coordinator.data.get(COORD_DATA_PROCESSED_FILES) == 0
 
-    # Simulate a parse result
-    timestamp_str = "2023-01-01T12:00:00+00:00"
-    mock_result = ParseResult(
-        duration=42.5,
-        timestamp=timestamp_str,
-        processed_files_count=100,
-        ignored_files_count=10
-    )
+        # Simulate a parse result
+        timestamp_str = "2023-01-01T12:00:00+00:00"
+        mock_result = ParseResult(
+            duration=42.5,
+            timestamp=timestamp_str,
+            processed_files_count=100,
+            ignored_files_count=10
+        )
 
-    # Call save stats
-    await coordinator.async_save_stats(mock_result)
+        # Call save stats
+        await coordinator.async_save_stats(mock_result)
 
-    # VERIFY: In-memory data should be updated IMMEDIATELY
-    # This is expected to FAIL before the fix
-    assert coordinator.data[COORD_DATA_PARSE_DURATION] == 42.5
-    assert coordinator.data[COORD_DATA_PROCESSED_FILES] == 100
-    assert coordinator.data[COORD_DATA_IGNORED_FILES] == 10
-    
-    # Check timestamp conversion
-    last_parse = coordinator.data[COORD_DATA_LAST_PARSE]
-    assert last_parse is not None
-    assert last_parse.isoformat() == timestamp_str
+        # VERIFY: In-memory data should be updated IMMEDIATELY
+        # This is expected to FAIL before the fix
+        assert coordinator.data[COORD_DATA_PARSE_DURATION] == 42.5
+        assert coordinator.data[COORD_DATA_PROCESSED_FILES] == 100
+        assert coordinator.data[COORD_DATA_IGNORED_FILES] == 10
+        
+        # Check timestamp conversion
+        last_parse = coordinator.data[COORD_DATA_LAST_PARSE]
+        assert last_parse is not None
+        assert last_parse.isoformat() == timestamp_str
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/tests/test_db_resilience.py
+++ b/tests/tests/test_db_resilience.py
@@ -14,22 +14,26 @@ async def test_coordinator_resilience_read_timeout(hass, tmp_path):
     config_dir = tmp_path / "config"
     config_dir.mkdir()
 
-    await async_init_integration(hass, add_params={"included_folders": [str(config_dir)]})
-    coordinator = hass.data[DOMAIN][hass.config_entries.async_entries(DOMAIN)[0].entry_id]
+    config_entry = await async_init_integration(hass, add_params={"included_folders": [str(config_dir)]})
+    try:
+        coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    # Mock parser.get_found_items to raise OperationalError (database locked)
-    with patch.object(WatchmanParser, 'get_found_items', side_effect=sqlite3.OperationalError("database is locked")):
+        # Mock parser.get_found_items to raise OperationalError (database locked)
+        with patch.object(WatchmanParser, 'get_found_items', side_effect=sqlite3.OperationalError("database is locked")):
 
-        # Trigger refresh
-        await coordinator.async_refresh()
+            # Trigger refresh
+            await coordinator.async_refresh()
+            await hass.async_block_till_done()
+
+            # Verify coordinator did NOT fail
+            assert coordinator.last_update_success is True, "Coordinator should succeed even if DB read fails"
+
+            # Verify data gracefully degraded (empty results -> 0 missing)
+            # Note: If cache was empty, it returns empty list -> 0 missing.
+            assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 0
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
-
-        # Verify coordinator did NOT fail
-        assert coordinator.last_update_success is True, "Coordinator should succeed even if DB read fails"
-
-        # Verify data gracefully degraded (empty results -> 0 missing)
-        # Note: If cache was empty, it returns empty list -> 0 missing.
-        assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 0
 
 @pytest.mark.asyncio
 async def test_coordinator_resilience_parse_timeout(hass, tmp_path):
@@ -37,16 +41,20 @@ async def test_coordinator_resilience_parse_timeout(hass, tmp_path):
     config_dir = tmp_path / "config"
     config_dir.mkdir()
 
-    await async_init_integration(hass, add_params={"included_folders": [str(config_dir)]})
-    coordinator = hass.data[DOMAIN][hass.config_entries.async_entries(DOMAIN)[0].entry_id]
+    config_entry = await async_init_integration(hass, add_params={"included_folders": [str(config_dir)]})
+    try:
+        coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    # Mock _init_db to raise OperationalError
-    # This allows scan() code to run and its try-except block to catch the error
-    with patch.object(WatchmanParser, '_init_db', side_effect=sqlite3.OperationalError("database is locked")):
+        # Mock _init_db to raise OperationalError
+        # This allows scan() code to run and its try-except block to catch the error
+        with patch.object(WatchmanParser, '_init_db', side_effect=sqlite3.OperationalError("database is locked")):
 
-        # Request parsing
-        await coordinator._async_update_data()
-        # Should not raise exception (test passes if no unhandled exception)
+            # Request parsing
+            await coordinator._async_update_data()
+            # Should not raise exception (test passes if no unhandled exception)
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
 
 @pytest.mark.asyncio
 async def test_coordinator_resilience_info_timeout(hass, tmp_path):
@@ -54,17 +62,21 @@ async def test_coordinator_resilience_info_timeout(hass, tmp_path):
     config_dir = tmp_path / "config"
     config_dir.mkdir()
 
-    await async_init_integration(hass, add_params={"included_folders": [str(config_dir)]})
-    coordinator = hass.data[DOMAIN][hass.config_entries.async_entries(DOMAIN)[0].entry_id]
+    config_entry = await async_init_integration(hass, add_params={"included_folders": [str(config_dir)]})
+    try:
+        coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    # Mock get_last_parse_info to raise OperationalError
-    with patch.object(
-        WatchmanParser,
-        "get_last_parse_info",
-        side_effect=sqlite3.OperationalError("database is locked"),
-    ):
-        info = await coordinator.hub.async_get_last_parse_info()
+        # Mock get_last_parse_info to raise OperationalError
+        with patch.object(
+            WatchmanParser,
+            "get_last_parse_info",
+            side_effect=sqlite3.OperationalError("database is locked"),
+        ):
+            info = await coordinator.hub.async_get_last_parse_info()
 
-        # Verify default values returned
-        assert info["duration"] == 0.0
-        assert info["processed_files_count"] == 0
+            # Verify default values returned
+            assert info["duration"] == 0.0
+            assert info["processed_files_count"] == 0
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/tests/test_event_noise_reduction.py
+++ b/tests/tests/test_event_noise_reduction.py
@@ -14,59 +14,62 @@ async def test_event_noise_reduction(hass, tmp_path):
     config_dir.mkdir()
     (config_dir / "test.yaml").write_text("sensor:\n  - platform: template\n    sensors:\n      test:\n        value_template: '{{ states.sensor.noise_test }}'", encoding="utf-8")
 
-    await async_init_integration(hass, add_params={CONF_INCLUDED_FOLDERS: str(config_dir)})
-    await hass.async_block_till_done()
+    config_entry = await async_init_integration(hass, add_params={CONF_INCLUDED_FOLDERS: str(config_dir)})
+    try:
+        await hass.async_block_till_done()
 
-    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
-    coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+        coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    # Helper to simulate state change and check if refresh called
-    async def verify_event(old_state_val, new_state_val, should_trigger):
-        with patch.object(coordinator, "async_request_refresh") as mock_refresh:
-            old = MagicMock(state=old_state_val) if old_state_val is not None else None
-            new = MagicMock(state=new_state_val) if new_state_val is not None else None
-            
-            hass.bus.async_fire(EVENT_STATE_CHANGED, {
-                "entity_id": "sensor.noise_test",
-                "old_state": old,
-                "new_state": new
-            })
-            await hass.async_block_till_done()
-            
-            if should_trigger:
-                assert mock_refresh.called, f"Should trigger for {old_state_val} -> {new_state_val}"
-                assert "sensor.noise_test" in coordinator._dirty_entities
-            else:
-                assert not mock_refresh.called, f"Should NOT trigger for {old_state_val} -> {new_state_val}"
+        # Helper to simulate state change and check if refresh called
+        async def verify_event(old_state_val, new_state_val, should_trigger):
+            with patch.object(coordinator, "async_request_refresh") as mock_refresh:
+                old = MagicMock(state=old_state_val) if old_state_val is not None else None
+                new = MagicMock(state=new_state_val) if new_state_val is not None else None
+                
+                hass.bus.async_fire(EVENT_STATE_CHANGED, {
+                    "entity_id": "sensor.noise_test",
+                    "old_state": old,
+                    "new_state": new
+                })
+                await hass.async_block_till_done()
+                
+                if should_trigger:
+                    assert mock_refresh.called, f"Should trigger for {old_state_val} -> {new_state_val}"
+                    assert "sensor.noise_test" in coordinator._dirty_entities
+                else:
+                    assert not mock_refresh.called, f"Should NOT trigger for {old_state_val} -> {new_state_val}"
 
-    # 1. Active -> Active (1 -> 2)
-    # Should IGNORE
-    await verify_event("1", "2", False)
+        # 1. Active -> Active (1 -> 2)
+        # Should IGNORE
+        await verify_event("1", "2", False)
 
-    # 2. Attribute Change (1 -> 1)
-    # Should IGNORE
-    await verify_event("1", "1", False)
+        # 2. Attribute Change (1 -> 1)
+        # Should IGNORE
+        await verify_event("1", "1", False)
 
-    # 3. Missing -> Active (unavailable -> on)
-    # Should CAPTURE
-    await verify_event("unavailable", "on", True)
-    coordinator._dirty_entities.clear() # Reset
+        # 3. Missing -> Active (unavailable -> on)
+        # Should CAPTURE
+        await verify_event("unavailable", "on", True)
+        coordinator._dirty_entities.clear() # Reset
 
-    # 4. Active -> Missing (on -> unavailable)
-    # Should CAPTURE
-    await verify_event("on", "unavailable", True)
-    coordinator._dirty_entities.clear()
+        # 4. Active -> Missing (on -> unavailable)
+        # Should CAPTURE
+        await verify_event("on", "unavailable", True)
+        coordinator._dirty_entities.clear()
 
-    # 5. Entity Creation (None -> on)
-    # Should CAPTURE
-    await verify_event(None, "on", True)
-    coordinator._dirty_entities.clear()
+        # 5. Entity Creation (None -> on)
+        # Should CAPTURE
+        await verify_event(None, "on", True)
+        coordinator._dirty_entities.clear()
 
-    # 6. Missing -> Missing (unknown -> unavailable)
-    # Should IGNORE
-    await verify_event("unknown", "unavailable", False)
+        # 6. Missing -> Missing (unknown -> unavailable)
+        # Should IGNORE
+        await verify_event("unknown", "unavailable", False)
 
-    # 7. Entity Removal (on -> None)
-    # Should CAPTURE
-    await verify_event("on", None, True)
-    coordinator._dirty_entities.clear()
+        # 7. Entity Removal (on -> None)
+        # Should CAPTURE
+        await verify_event("on", None, True)
+        coordinator._dirty_entities.clear()
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/tests/test_ignored_items.py
+++ b/tests/tests/test_ignored_items.py
@@ -28,27 +28,31 @@ async def test_ignored_items_exact_match(hass: HomeAssistant):
         },
     )
     
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
-    
-    # Check Entities
-    # sensor.skylight should be ignored
-    # switch.skylight should be reported
-    
-    entity_attrs = coordinator.data.get("entity_attrs", [])
-    missing_entity_ids = [e["id"] for e in entity_attrs]
-    
-    assert "sensor.skylight" not in missing_entity_ids, "sensor.skylight should be ignored"
-    assert "switch.skylight" in missing_entity_ids, "switch.skylight should be reported"
-    
-    # Check Services
-    # switch.turn_off should be ignored
-    # switch.turn_on should be reported
-    
-    service_attrs = coordinator.data.get("service_attrs", [])
-    missing_service_ids = [s["id"] for s in service_attrs]
-    
-    assert "switch.turn_off" not in missing_service_ids, "switch.turn_off should be ignored"
-    assert "switch.turn_on" in missing_service_ids, "switch.turn_on should be reported"
+    try:
+        coordinator = hass.data[DOMAIN][config_entry.entry_id]
+        
+        # Check Entities
+        # sensor.skylight should be ignored
+        # switch.skylight should be reported
+        
+        entity_attrs = coordinator.data.get("entity_attrs", [])
+        missing_entity_ids = [e["id"] for e in entity_attrs]
+        
+        assert "sensor.skylight" not in missing_entity_ids, "sensor.skylight should be ignored"
+        assert "switch.skylight" in missing_entity_ids, "switch.skylight should be reported"
+        
+        # Check Services
+        # switch.turn_off should be ignored
+        # switch.turn_on should be reported
+        
+        service_attrs = coordinator.data.get("service_attrs", [])
+        missing_service_ids = [s["id"] for s in service_attrs]
+        
+        assert "switch.turn_off" not in missing_service_ids, "switch.turn_off should be ignored"
+        assert "switch.turn_on" in missing_service_ids, "switch.turn_on should be reported"
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
 
 
 @pytest.mark.asyncio
@@ -65,23 +69,27 @@ async def test_ignored_items_glob_match(hass: HomeAssistant):
         },
     )
     
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
-    
-    # Check Entities
-    # switch.skylight should be ignored (matches switch.*)
-    # sensor.skylight should be reported
-    
-    entity_attrs = coordinator.data.get("entity_attrs", [])
-    missing_entity_ids = [e["id"] for e in entity_attrs]
-    
-    assert "switch.skylight" not in missing_entity_ids, "switch.skylight should be ignored by glob"
-    assert "sensor.skylight" in missing_entity_ids, "sensor.skylight should be reported"
-    
-    # Check Services
-    # switch.turn_on and switch.turn_off should be ignored (matches switch.*)
-    
-    service_attrs = coordinator.data.get("service_attrs", [])
-    missing_service_ids = [s["id"] for s in service_attrs]
-    
-    assert "switch.turn_on" not in missing_service_ids
-    assert "switch.turn_off" not in missing_service_ids
+    try:
+        coordinator = hass.data[DOMAIN][config_entry.entry_id]
+        
+        # Check Entities
+        # switch.skylight should be ignored (matches switch.*)
+        # sensor.skylight should be reported
+        
+        entity_attrs = coordinator.data.get("entity_attrs", [])
+        missing_entity_ids = [e["id"] for e in entity_attrs]
+        
+        assert "switch.skylight" not in missing_entity_ids, "switch.skylight should be ignored by glob"
+        assert "sensor.skylight" in missing_entity_ids, "sensor.skylight should be reported"
+        
+        # Check Services
+        # switch.turn_on and switch.turn_off should be ignored (matches switch.*)
+        
+        service_attrs = coordinator.data.get("service_attrs", [])
+        missing_service_ids = [s["id"] for s in service_attrs]
+        
+        assert "switch.turn_on" not in missing_service_ids
+        assert "switch.turn_off" not in missing_service_ids
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/tests/test_init.py
+++ b/tests/tests/test_init.py
@@ -17,33 +17,38 @@ async def test_integration_removal_cleanup(hass: HomeAssistant):
     config_entry = await async_init_integration(hass)
     assert config_entry.state == ConfigEntryState.LOADED
 
-    # 2. Verify DB file exists
-    db_path = Path(hass.config.path(".storage", DB_FILENAME))
-    journal_path = Path(str(db_path) + "-journal")
-    lock_path = Path(hass.config.path(".storage", LOCK_FILENAME))
-    stats_path = Path(hass.config.path(".storage", STORAGE_KEY))
+    try:
+        # 2. Verify DB file exists
+        db_path = Path(hass.config.path(".storage", DB_FILENAME))
+        journal_path = Path(str(db_path) + "-journal")
+        lock_path = Path(hass.config.path(".storage", LOCK_FILENAME))
+        stats_path = Path(hass.config.path(".storage", STORAGE_KEY))
 
-    # Manually create journal and lock files if they don't exist (simulating active usage/crash)
-    # The integration creates .db, but journal might be transient in WAL/TRUNCATE unless active
-    if not journal_path.exists():
-        journal_path.touch()
-    if not lock_path.exists():
-        lock_path.touch()
-    # Ensure stats file exists (created by coordinator, but let's be sure)
-    if not stats_path.exists():
-        stats_path.touch()
+        # Manually create journal and lock files if they don't exist (simulating active usage/crash)
+        # The integration creates .db, but journal might be transient in WAL/TRUNCATE unless active
+        if not journal_path.exists():
+            journal_path.touch()
+        if not lock_path.exists():
+            lock_path.touch()
+        # Ensure stats file exists (created by coordinator, but let's be sure)
+        if not stats_path.exists():
+            stats_path.touch()
 
-    assert db_path.exists()
-    assert journal_path.exists()
-    assert lock_path.exists()
-    assert stats_path.exists()
+        assert db_path.exists()
+        assert journal_path.exists()
+        assert lock_path.exists()
+        assert stats_path.exists()
 
-    # 3. Remove integration
-    await hass.config_entries.async_remove(config_entry.entry_id)
-    await hass.async_block_till_done()
+        # 3. Remove integration
+        await hass.config_entries.async_remove(config_entry.entry_id)
+        await hass.async_block_till_done()
 
-    # 4. Verify all files are removed
-    assert not db_path.exists(), "Database file not removed"
-    assert not journal_path.exists(), "Journal file not removed"
-    assert not lock_path.exists(), "Lock file not removed"
-    assert not stats_path.exists(), "Stats file not removed"
+        # 4. Verify all files are removed
+        assert not db_path.exists(), "Database file not removed"
+        assert not journal_path.exists(), "Journal file not removed"
+        assert not lock_path.exists(), "Lock file not removed"
+        assert not stats_path.exists(), "Stats file not removed"
+    finally:
+        if config_entry.state != ConfigEntryState.NOT_LOADED:
+            await hass.config_entries.async_unload(config_entry.entry_id)
+            await hass.async_block_till_done()

--- a/tests/tests/test_migration.py
+++ b/tests/tests/test_migration.py
@@ -182,8 +182,11 @@ async def test_migrate_v2_downgrade_compatibility(hass: HomeAssistant):
         mock_coordinator.safe_mode = False
         
         # Run setup
-        result = await async_setup_entry(hass, mock_entry)
-        
-        assert result is True
-        mock_forward.assert_called_once()
-        # Verify no crash
+        try:
+            result = await async_setup_entry(hass, mock_entry)
+            assert result is True
+            mock_forward.assert_called_once()
+            # Verify no crash
+        finally:
+            await hass.config_entries.async_unload(mock_entry.entry_id)
+            await hass.async_block_till_done()

--- a/tests/tests/test_new_sensors.py
+++ b/tests/tests/test_new_sensors.py
@@ -17,56 +17,60 @@ from homeassistant.helpers import entity_registry as er
 
 async def test_diagnostic_sensors(hass: HomeAssistant):
     """Test the new diagnostic sensors."""
-    await async_init_integration(hass)
+    config_entry = await async_init_integration(hass)
 
-    ent_reg = er.async_get(hass)
-    entity_registry = list(ent_reg.entities.values())
+    try:
+        ent_reg = er.async_get(hass)
+        entity_registry = list(ent_reg.entities.values())
 
-    # Helper to find entity_id by suffix
-    def get_entity_id(suffix):
-        return next(e.entity_id for e in entity_registry if e.unique_id.endswith(suffix))
+        # Helper to find entity_id by suffix
+        def get_entity_id(suffix):
+            return next(e.entity_id for e in entity_registry if e.unique_id.endswith(suffix))
 
-    # 1. Verify Sensors Exist and have correct Category
-    sensors = [
-        SENSOR_PARSE_DURATION,
-        SENSOR_LAST_PARSE,
-        SENSOR_PROCESSED_FILES,
-        SENSOR_IGNORED_FILES
-    ]
+        # 1. Verify Sensors Exist and have correct Category
+        sensors = [
+            SENSOR_PARSE_DURATION,
+            SENSOR_LAST_PARSE,
+            SENSOR_PROCESSED_FILES,
+            SENSOR_IGNORED_FILES
+        ]
 
-    for sensor_suffix in sensors:
-        entity_id = get_entity_id(sensor_suffix)
-        entry = ent_reg.async_get(entity_id)
-        assert entry is not None
-        assert entry.entity_category == EntityCategory.DIAGNOSTIC, f"{sensor_suffix} should be DIAGNOSTIC"
+        for sensor_suffix in sensors:
+            entity_id = get_entity_id(sensor_suffix)
+            entry = ent_reg.async_get(entity_id)
+            assert entry is not None
+            assert entry.entity_category == EntityCategory.DIAGNOSTIC, f"{sensor_suffix} should be DIAGNOSTIC"
 
-    # 2. Trigger a scan and verify values update
-    coordinator = hass.data[DOMAIN][hass.config_entries.async_entries(DOMAIN)[0].entry_id]
+        # 2. Trigger a scan and verify values update
+        coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    from custom_components.watchman.utils.parser_core import ParseResult
+        from custom_components.watchman.utils.parser_core import ParseResult
 
-    # Simulate parse results
-    mock_result = ParseResult(
-        duration=12.5,
-        timestamp="2023-01-01T12:00:00+00:00",
-        processed_files_count=42,
-        ignored_files_count=5
-    )
+        # Simulate parse results
+        mock_result = ParseResult(
+            duration=12.5,
+            timestamp="2023-01-01T12:00:00+00:00",
+            processed_files_count=42,
+            ignored_files_count=5
+        )
 
-    await coordinator.async_save_stats(mock_result)
-    await coordinator.async_refresh()
-    await hass.async_block_till_done()
+        await coordinator.async_save_stats(mock_result)
+        await coordinator.async_refresh()
+        await hass.async_block_till_done()
 
-    # Verify Values
-    processed_id = get_entity_id(SENSOR_PROCESSED_FILES)
-    assert hass.states.get(processed_id).state == "42"
+        # Verify Values
+        processed_id = get_entity_id(SENSOR_PROCESSED_FILES)
+        assert hass.states.get(processed_id).state == "42"
 
-    ignored_id = get_entity_id(SENSOR_IGNORED_FILES)
-    assert hass.states.get(ignored_id).state == "5"
+        ignored_id = get_entity_id(SENSOR_IGNORED_FILES)
+        assert hass.states.get(ignored_id).state == "5"
 
-    duration_id = get_entity_id(SENSOR_PARSE_DURATION)
-    assert hass.states.get(duration_id).state == "12.5"
+        duration_id = get_entity_id(SENSOR_PARSE_DURATION)
+        assert hass.states.get(duration_id).state == "12.5"
 
-    last_parse_id = get_entity_id(SENSOR_LAST_PARSE)
-    # HA handles timestamp formatting, but it should be present
-    assert hass.states.get(last_parse_id).state == "2023-01-01T12:00:00+00:00"
+        last_parse_id = get_entity_id(SENSOR_LAST_PARSE)
+        # HA handles timestamp formatting, but it should be present
+        assert hass.states.get(last_parse_id).state == "2023-01-01T12:00:00+00:00"
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/tests/test_obfuscation.py
+++ b/tests/tests/test_obfuscation.py
@@ -97,15 +97,19 @@ async def test_integration_obfuscate_config(hass):
         }
     )
     
-    # Verify global state changed
-    assert obfuscate_id("sensor.secret") == "sensor.secret"
-    
-    # Reload with True
-    hass.config_entries.async_update_entry(
-        config_entry, data={**config_entry.data, CONF_LOG_OBFUSCATE: True}
-    )
-    await hass.config_entries.async_reload(config_entry.entry_id)
-    await hass.async_block_till_done()
-    
-    # Verify global state changed back
-    assert obfuscate_id("sensor.secret") == "sensor.sec***"
+    try:
+        # Verify global state changed
+        assert obfuscate_id("sensor.secret") == "sensor.secret"
+        
+        # Reload with True
+        hass.config_entries.async_update_entry(
+            config_entry, data={**config_entry.data, CONF_LOG_OBFUSCATE: True}
+        )
+        await hass.config_entries.async_reload(config_entry.entry_id)
+        await hass.async_block_till_done()
+        
+        # Verify global state changed back
+        assert obfuscate_id("sensor.secret") == "sensor.sec***"
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/tests/test_options_flow.py
+++ b/tests/tests/test_options_flow.py
@@ -52,39 +52,44 @@ async def test_options_flow_labels(hass: HomeAssistant):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         
-        # 2. Interaction
-        result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        
-        assert result["type"] == FlowResultType.FORM
-        assert result["step_id"] == "init"
-        
-        # Check schema has the key
-        schema = result["data_schema"]
-        assert CONF_IGNORED_LABELS in schema.schema
-        
-        # Simulate user selecting "test" and "private"
-        # We must provide all required fields as per schema
-        
-        user_input = {
-            CONF_IGNORED_LABELS: ["test", "private"],
-            CONF_STARTUP_DELAY: 30,
-            CONF_SECTION_APPEARANCE_LOCATION: {
-                CONF_REPORT_PATH: "/config/report.txt",
-                CONF_HEADER: "-== Watchman Report ==-",
-                CONF_COLUMNS_WIDTH: "30, 8, 60"
+        try:
+            # 2. Interaction
+            result = await hass.config_entries.options.async_init(config_entry.entry_id)
+            
+            assert result["type"] == FlowResultType.FORM
+            assert result["step_id"] == "init"
+            
+            # Check schema has the key
+            schema = result["data_schema"]
+            assert CONF_IGNORED_LABELS in schema.schema
+            
+            # Simulate user selecting "test" and "private"
+            # We must provide all required fields as per schema
+            
+            user_input = {
+                CONF_IGNORED_LABELS: ["test", "private"],
+                CONF_STARTUP_DELAY: 30,
+                CONF_SECTION_APPEARANCE_LOCATION: {
+                    CONF_REPORT_PATH: "/config/report.txt",
+                    CONF_HEADER: "-== Watchman Report ==-",
+                    CONF_COLUMNS_WIDTH: "30, 8, 60"
+                }
             }
-        }
-        
-        # 3. Assertion
-        # We need to mock async_update_entry on hass.config_entries because the real one updates the entry object
-        # but we want to verify the call or just check the entry object afterwards.
-        # The real async_update_entry updates the entry in memory.
-        
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"], user_input=user_input
-        )
-        
-        assert result["type"] == FlowResultType.CREATE_ENTRY
-        
-        # Verify persistence
-        assert config_entry.data[CONF_IGNORED_LABELS] == ["test", "private"]
+            
+            # 3. Assertion
+            # We need to mock async_update_entry on hass.config_entries because the real one updates the entry object
+            # but we want to verify the call or just check the entry object afterwards.
+            # The real async_update_entry updates the entry in memory.
+            
+            result = await hass.config_entries.options.async_configure(
+                result["flow_id"], user_input=user_input
+            )
+            await hass.async_block_till_done() # Wait for possible reload
+            
+            assert result["type"] == FlowResultType.CREATE_ENTRY
+            
+            # Verify persistence
+            assert config_entry.data[CONF_IGNORED_LABELS] == ["test", "private"]
+        finally:
+            await hass.config_entries.async_unload(config_entry.entry_id)
+            await hass.async_block_till_done()

--- a/tests/tests/test_race_conditions.py
+++ b/tests/tests/test_race_conditions.py
@@ -30,77 +30,81 @@ async def test_request_during_scan(hass: HomeAssistant, mock_hub_parse):
     lock_path_obj.unlink(missing_ok=True)
 
     config_entry = await async_init_integration(hass)
-    coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    try:
+        coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    if coordinator.safe_mode:
-        coordinator.update_status(STATE_IDLE)
+        if coordinator.safe_mode:
+            coordinator.update_status(STATE_IDLE)
 
-    # 1. Start a scan that takes some time
-    finish_first_parse = asyncio.Event()
+        # 1. Start a scan that takes some time
+        finish_first_parse = asyncio.Event()
 
-    from custom_components.watchman.utils.parser_core import ParseResult
+        from custom_components.watchman.utils.parser_core import ParseResult
 
-    async def slow_parse(*args, **kwargs):
-        await finish_first_parse.wait()
-        return ParseResult(
-            duration=1.0,
-            timestamp="2026-01-01T12:00:00",
-            processed_files_count=1,
-            ignored_files_count=0,
-        )
+        async def slow_parse(*args, **kwargs):
+            await finish_first_parse.wait()
+            return ParseResult(
+                duration=1.0,
+                timestamp="2026-01-01T12:00:00",
+                processed_files_count=1,
+                ignored_files_count=0,
+            )
 
-    mock_hub_parse.side_effect = slow_parse
-    mock_hub_parse.reset_mock()
-    coordinator._last_parse_time = 0
+        mock_hub_parse.side_effect = slow_parse
+        mock_hub_parse.reset_mock()
+        coordinator._last_parse_time = 0
 
-    # Trigger first scan
-    coordinator.request_parser_rescan(reason="first", delay=0)
+        # Trigger first scan
+        coordinator.request_parser_rescan(reason="first", delay=0)
 
-    # Wait for the task to start and reach the mock
-    for _ in range(10):
-        if coordinator.status == "parsing":
-            break
-        await asyncio.sleep(0.1)
+        # Wait for the task to start and reach the mock
+        for _ in range(10):
+            if coordinator.status == "parsing":
+                break
+            await asyncio.sleep(0.1)
 
-    # Verify scan is running
-    assert coordinator.status == "parsing"
+        # Verify scan is running
+        assert coordinator.status == "parsing"
 
-    # 2. Request another rescan while first is running
-    coordinator.request_parser_rescan(reason="during_scan", delay=1)
+        # 2. Request another rescan while first is running
+        coordinator.request_parser_rescan(reason="during_scan", delay=1)
 
-    # Verify no delay timer was created (because scan is in progress)
-    assert coordinator._delay_unsub is None
-    # Verify flag is set
-    assert coordinator._needs_parse is True
+        # Verify no delay timer was created (because scan is in progress)
+        assert coordinator._delay_unsub is None
+        # Verify flag is set
+        assert coordinator._needs_parse is True
 
-    # 3. Finish the first scan
-    finish_first_parse.set()
+        # 3. Finish the first scan
+        finish_first_parse.set()
 
-    # Wait for it to finish and trigger the next one (which will be cooldown)
-    for _ in range(10):
-        if coordinator._cooldown_unsub is not None:
-            break
-        await asyncio.sleep(0.1)
+        # Wait for it to finish and trigger the next one (which will be cooldown)
+        for _ in range(10):
+            if coordinator._cooldown_unsub is not None:
+                break
+            await asyncio.sleep(0.1)
 
-    # The first parse finished. Because _needs_parse was True, it should have called _schedule_parse.
-    # Since it's immediately after parse, it should hit COOLDOWN logic.
-    assert coordinator._cooldown_unsub is not None
-    assert coordinator.status == "pending"
+        # The first parse finished. Because _needs_parse was True, it should have called _schedule_parse.
+        # Since it's immediately after parse, it should hit COOLDOWN logic.
+        assert coordinator._cooldown_unsub is not None
+        assert coordinator.status == "pending"
 
-    # 4. Advance time to pass cooldown
-    # Manipulate time to satisfy check
-    coordinator._last_parse_time -= (PARSE_COOLDOWN + 5)
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=PARSE_COOLDOWN + 5))
-    await hass.async_block_till_done()
+        # 4. Advance time to pass cooldown
+        # Manipulate time to satisfy check
+        coordinator._last_parse_time -= (PARSE_COOLDOWN + 5)
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=PARSE_COOLDOWN + 5))
+        await hass.async_block_till_done()
 
-    # Wait for the second parse to finish (we need to clear the side effect or it will hang again)
-    mock_hub_parse.side_effect = None
+        # Wait for the second parse to finish (we need to clear the side effect or it will hang again)
+        mock_hub_parse.side_effect = None
 
-    # Wait for background task
-    for _ in range(10):
-        if mock_hub_parse.call_count >= 2:
-            break
-        await asyncio.sleep(0.1)
+        # Wait for background task
+        for _ in range(10):
+            if mock_hub_parse.call_count >= 2:
+                break
+            await asyncio.sleep(0.1)
 
-    # Should have been called twice (once for first, once for queued)
-    assert mock_hub_parse.call_count >= 2
+        # Should have been called twice (once for first, once for queued)
+        assert mock_hub_parse.call_count >= 2
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/tests/test_report_context.py
+++ b/tests/tests/test_report_context.py
@@ -71,30 +71,34 @@ async def test_report_context_inclusion(hass):
     entry.title = "Watchman"
     coordinator = WatchmanCoordinator(hass, None, entry, hub, version="1.0.0")
     
-    # Mock get_config to allow everything
-    def get_config_side_effect(hass, key, default=None):
-        return default
+    try:
+        # Mock get_config to allow everything
+        def get_config_side_effect(hass, key, default=None):
+            return default
 
-    with patch("custom_components.watchman.coordinator.get_config", side_effect=get_config_side_effect):
-        # By default hass.states.get returns None (missing) which is what we want
-        
-        report_data = await coordinator.async_get_detailed_report_data()
-        
-        missing_entities = report_data["missing_entities"]
-        
-        # Verify Sensor Context
-        sensor_entry = next((e for e in missing_entities if e["id"] == "sensor.test_sensor"), None)
-        assert sensor_entry is not None, "Sensor entry missing from report"
-        assert sensor_entry["context"]["parent_type"] == "automation"
-        assert sensor_entry["context"]["parent_alias"] == "Kitchen Lights"
-        
-        # Verify Light Context
-        light_entry = next((e for e in missing_entities if e["id"] == "light.living_room"), None)
-        assert light_entry is not None, "Light entry missing from report"
-        assert light_entry["context"]["parent_type"] == "script"
-        assert light_entry["context"]["parent_alias"] == "Good Night"
-        
-        # Verify No Context
-        no_context_entry = next((e for e in missing_entities if e["id"] == "sensor.no_context"), None)
-        assert no_context_entry is not None, "No context entry missing from report"
-        assert no_context_entry["context"] is None
+        with patch("custom_components.watchman.coordinator.get_config", side_effect=get_config_side_effect):
+            # By default hass.states.get returns None (missing) which is what we want
+            
+            report_data = await coordinator.async_get_detailed_report_data()
+            
+            missing_entities = report_data["missing_entities"]
+            
+            # Verify Sensor Context
+            sensor_entry = next((e for e in missing_entities if e["id"] == "sensor.test_sensor"), None)
+            assert sensor_entry is not None, "Sensor entry missing from report"
+            assert sensor_entry["context"]["parent_type"] == "automation"
+            assert sensor_entry["context"]["parent_alias"] == "Kitchen Lights"
+            
+            # Verify Light Context
+            light_entry = next((e for e in missing_entities if e["id"] == "light.living_room"), None)
+            assert light_entry is not None, "Light entry missing from report"
+            assert light_entry["context"]["parent_type"] == "script"
+            assert light_entry["context"]["parent_alias"] == "Good Night"
+            
+            # Verify No Context
+            no_context_entry = next((e for e in missing_entities if e["id"] == "sensor.no_context"), None)
+            assert no_context_entry is not None, "No context entry missing from report"
+            assert no_context_entry["context"] is None
+    finally:
+        await coordinator.async_shutdown()
+        await hass.async_block_till_done()

--- a/tests/tests/test_report_generation.py
+++ b/tests/tests/test_report_generation.py
@@ -38,7 +38,7 @@ async def test_report_generation_snapshot(hass, new_test_data_dir, tmp_path, sna
     report_file = tmp_path / "watchman_report.txt"
 
     # Initialize integration pointing to our dedicated folder
-    await async_init_integration(
+    config_entry = await async_init_integration(
         hass,
         add_params={
             CONF_INCLUDED_FOLDERS: config_dir,
@@ -49,41 +49,45 @@ async def test_report_generation_snapshot(hass, new_test_data_dir, tmp_path, sna
         },
     )
 
-    # Set some states so they are NOT reported as missing (to reduce noise or verify filtering)
-    # But leave many missing so the report is populated.
-    hass.states.async_set("sensor.outside_temp", "25.0") # Exists
-    hass.states.async_set("light.living_room", "on") # Exists
-    hass.states.async_set("binary_sensor.motion_sensor", "unavailable") # Unavailable
-    hass.states.async_set("input_boolean.unknown_boolean", "unknown") # Unknown
+    try:
+        # Set some states so they are NOT reported as missing (to reduce noise or verify filtering)
+        # But leave many missing so the report is populated.
+        hass.states.async_set("sensor.outside_temp", "25.0") # Exists
+        hass.states.async_set("light.living_room", "on") # Exists
+        hass.states.async_set("binary_sensor.motion_sensor", "unavailable") # Unavailable
+        hass.states.async_set("input_boolean.unknown_boolean", "unknown") # Unknown
 
-    # Register dummy services for standard domains so they are detected as "available"
-    # This mimics a real HA instance where these integrations are loaded.
-    for domain in ["light", "switch", "alarm_control_panel", "vacuum", "script", "notify", "automation"]:
-        hass.services.async_register(domain, "turn_on", lambda x: None)
-        hass.services.async_register(domain, "turn_off", lambda x: None)
-        hass.services.async_register(domain, "toggle", lambda x: None)
-        # Add specific services used in test data
+        # Register dummy services for standard domains so they are detected as "available"
+        # This mimics a real HA instance where these integrations are loaded.
+        for domain in ["light", "switch", "alarm_control_panel", "vacuum", "script", "notify", "automation"]:
+            hass.services.async_register(domain, "turn_on", lambda x: None)
+            hass.services.async_register(domain, "turn_off", lambda x: None)
+            hass.services.async_register(domain, "toggle", lambda x: None)
+            # Add specific services used in test data
 
-    hass.services.async_register("alarm_control_panel", "arm_home", lambda x: None)
-    hass.services.async_register("vacuum", "start", lambda x: None)
-    hass.services.async_register("notify", "telegram", lambda x: None)
-    hass.services.async_register("notify", "persistent_notification", lambda x: None)
-    hass.services.async_register("notify", "mobile_app_phone", lambda x: None)
-    #hass.services.async_register("script", "cleanup_routine", lambda x: None)
+        hass.services.async_register("alarm_control_panel", "arm_home", lambda x: None)
+        hass.services.async_register("vacuum", "start", lambda x: None)
+        hass.services.async_register("notify", "telegram", lambda x: None)
+        hass.services.async_register("notify", "persistent_notification", lambda x: None)
+        hass.services.async_register("notify", "mobile_app_phone", lambda x: None)
+        #hass.services.async_register("script", "cleanup_routine", lambda x: None)
 
-    # Run report
-    await hass.services.async_call(DOMAIN, "report")
-    await hass.async_block_till_done()
+        # Run report
+        await hass.services.async_call(DOMAIN, "report")
+        await hass.async_block_till_done()
 
-    # Verify report created
-    assert report_file.exists()
+        # Verify report created
+        assert report_file.exists()
 
-    # Read content
-    content = report_file.read_text(encoding="utf-8")
+        # Read content
+        content = report_file.read_text(encoding="utf-8")
 
-    # Assert match snapshot
-    # We replace the absolute temp path in the report header if it appears there
-    # The header usually contains "Report created..."
-    # Check if absolute paths leak in the body. mock_get_short_path should handle file paths.
+        # Assert match snapshot
+        # We replace the absolute temp path in the report header if it appears there
+        # The header usually contains "Report created..."
+        # Check if absolute paths leak in the body. mock_get_short_path should handle file paths.
 
-    assert content == snapshot
+        assert content == snapshot
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/tests/test_report_sensor_sync.py
+++ b/tests/tests/test_report_sensor_sync.py
@@ -16,47 +16,50 @@ async def test_report_service_forces_full_rescan(hass, tmp_path):
     config_dir.mkdir()
     (config_dir / "test.yaml").write_text("sensor:\n  - platform: template\n    sensors:\n      test:\n        value_template: '{{ states.sensor.sync_test }}'", encoding="utf-8")
 
-    await async_init_integration(hass, add_params={CONF_INCLUDED_FOLDERS: str(config_dir)})
-    await hass.async_block_till_done()
-
-    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
-    coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-
-    # Verify initial state: 1 missing entity
-    assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 1
-    
-    # 2. Action: Set flag to False to simulate cached state
-    coordinator._force_full_rescan = False
-    coordinator._dirty_entities.clear()
-    
-    # Change state of the entity in HA but avoid triggering the coordinator's listener 
-    # (or just assume we want to prove Branch A is taken regardless of dirty set)
-    hass.states.async_set("sensor.sync_test", "on")
-    # Coordinator would usually be notified and set dirty, but we want to test the report service override.
-    # To be absolutely sure we test the override, we clear dirty entities again.
-    coordinator._dirty_entities.clear()
-    
-    # At this point:
-    # _force_full_rescan = False
-    # _dirty_entities = empty
-    # If we call refresh now, it would return 1 (cached).
-    
-    # 3. Call watchman.report service
-    import custom_components.watchman.coordinator as coord_module
-    original_renew = coord_module.renew_missing_items_list
-    
-    with patch("custom_components.watchman.coordinator.renew_missing_items_list", wraps=None) as mock_renew:
-        # We need the real function to execute so sensors update
-        mock_renew.side_effect = original_renew
-        
-        await hass.services.async_call(DOMAIN, "report", {"create_file": False}, blocking=True)
-        
-        # Service call schedules refresh. Trigger debounce.
-        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
+    config_entry = await async_init_integration(hass, add_params={CONF_INCLUDED_FOLDERS: str(config_dir)})
+    try:
         await hass.async_block_till_done()
+
+        coordinator: WatchmanCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+        # Verify initial state: 1 missing entity
+        assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 1
         
-        # Verify Branch A (Full Rescan) was taken
-        assert mock_renew.called, "Full rescan SHOULD be forced by report service"
+        # 2. Action: Set flag to False to simulate cached state
+        coordinator._force_full_rescan = False
+        coordinator._dirty_entities.clear()
         
-    # 4. Assert Final State: Sensors should be 0
-    assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 0
+        # Change state of the entity in HA but avoid triggering the coordinator's listener 
+        # (or just assume we want to prove Branch A is taken regardless of dirty set)
+        hass.states.async_set("sensor.sync_test", "on")
+        # Coordinator would usually be notified and set dirty, but we want to test the report service override.
+        # To be absolutely sure we test the override, we clear dirty entities again.
+        coordinator._dirty_entities.clear()
+        
+        # At this point:
+        # _force_full_rescan = False
+        # _dirty_entities = empty
+        # If we call refresh now, it would return 1 (cached).
+        
+        # 3. Call watchman.report service
+        import custom_components.watchman.coordinator as coord_module
+        original_renew = coord_module.renew_missing_items_list
+        
+        with patch("custom_components.watchman.coordinator.renew_missing_items_list", wraps=None) as mock_renew:
+            # We need the real function to execute so sensors update
+            mock_renew.side_effect = original_renew
+            
+            await hass.services.async_call(DOMAIN, "report", {"create_file": False}, blocking=True)
+            
+            # Service call schedules refresh. Trigger debounce.
+            async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
+            await hass.async_block_till_done()
+            
+            # Verify Branch A (Full Rescan) was taken
+            assert mock_renew.called, "Full rescan SHOULD be forced by report service"
+            
+        # 4. Assert Final State: Sensors should be 0
+        assert coordinator.data[COORD_DATA_MISSING_ENTITIES] == 0
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/tests/test_status_sensor.py
+++ b/tests/tests/test_status_sensor.py
@@ -25,83 +25,87 @@ async def test_status_sensor_states(hass: HomeAssistant):
     # 1. Initialize integration
     # In this test environment, setup completes and fires startup events usually,
     # so we expect it to settle at IDLE.
-    await async_init_integration(hass)
+    config_entry = await async_init_integration(hass)
 
-    # Get the sensor entity ID dynamically
-    entity_registry = list(er.async_get(hass).entities.values())
-    entity_id = next(e.entity_id for e in entity_registry if e.unique_id.endswith(SENSOR_STATUS))
+    try:
+        # Get the sensor entity ID dynamically
+        entity_registry = list(er.async_get(hass).entities.values())
+        entity_id = next(e.entity_id for e in entity_registry if e.unique_id.endswith(SENSOR_STATUS))
 
-    # Verify Initial State (Idle after startup)
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_IDLE, f"State after startup should be {STATE_IDLE}"
+        # Verify Initial State (Idle after startup)
+        state = hass.states.get(entity_id)
+        assert state.state == STATE_IDLE, f"State after startup should be {STATE_IDLE}"
 
-    # 2. Transition to PARSING: Trigger a scan
-    coordinator = hass.data[DOMAIN][hass.config_entries.async_entries(DOMAIN)[0].entry_id]
-    
-    # Speed up test by removing debouncer cooldown
-    coordinator.debouncer.cooldown = 0.0
-
-    # We use an event to coordinate the check during the 'parsing' phase
-    parsing_event = asyncio.Event()
-
-    # Mock the hub.async_parse to pause so we can check the state
-    original_parse = coordinator.hub.async_parse
-
-    async def mocked_async_parse(*args, **kwargs):
-        # Notify test that we are inside parsing
-        parsing_event.set()
+        # 2. Transition to PARSING: Trigger a scan
+        coordinator = hass.data[DOMAIN][config_entry.entry_id]
         
-        # Check state inside the execution context
-        current_state = hass.states.get(entity_id)
-        assert current_state.state == STATE_PARSING, f"State during parsing should be {STATE_PARSING}"
+        # Speed up test by removing debouncer cooldown
+        coordinator.debouncer.cooldown = 0.0
 
-    with patch.object(coordinator.hub, 'async_parse', side_effect=mocked_async_parse) as mock_parse, \
-            patch("custom_components.watchman.coordinator.PARSE_COOLDOWN", 0):
-        # Request a rescan to ensure parsing logic is triggered
-        # CRITICAL: set delay=0 to avoid default 10s delay
-        coordinator.request_parser_rescan(reason="Test", delay=0)
+        # We use an event to coordinate the check during the 'parsing' phase
+        parsing_event = asyncio.Event()
 
-        # Trigger an update (will be immediate due to debouncer cooldown=0)
-        task = asyncio.create_task(coordinator.async_request_refresh())
+        # Mock the hub.async_parse to pause so we can check the state
+        original_parse = coordinator.hub.async_parse
 
-        # Wait for the parsing to trigger
-        await parsing_event.wait()
+        async def mocked_async_parse(*args, **kwargs):
+            # Notify test that we are inside parsing
+            parsing_event.set()
+            
+            # Check state inside the execution context
+            current_state = hass.states.get(entity_id)
+            assert current_state.state == STATE_PARSING, f"State during parsing should be {STATE_PARSING}"
 
-        # Wait for the update to finish
-        await task
+        with patch.object(coordinator.hub, 'async_parse', side_effect=mocked_async_parse) as mock_parse, \
+                patch("custom_components.watchman.coordinator.PARSE_COOLDOWN", 0):
+            # Request a rescan to ensure parsing logic is triggered
+            # CRITICAL: set delay=0 to avoid default 10s delay
+            coordinator.request_parser_rescan(reason="Test", delay=0)
+
+            # Trigger an update (will be immediate due to debouncer cooldown=0)
+            task = asyncio.create_task(coordinator.async_request_refresh())
+
+            # Wait for the parsing to trigger
+            await parsing_event.wait()
+
+            # Wait for the update to finish
+            await task
+            await hass.async_block_till_done()
+
+            # Verify the mock assertion passed (implicitly by no exception)
+            mock_parse.assert_called()
+
+        # 3. Transition back to IDLE: After update finishes
+        # Use a loop to wait for state change as it happens in background task
+        async def wait_for_idle():
+            while True:
+                state = hass.states.get(entity_id)
+                if state.state == STATE_IDLE:
+                    return
+                await asyncio.sleep(0.1)
+
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(wait_for_idle(), timeout=2.0)
+
+        state = hass.states.get(entity_id)
+        assert state.state == STATE_IDLE, f"State after parsing should return to {STATE_IDLE}"
+
+        # 4. Transition to PENDING
+        # Now that we are IDLE, if we request another scan within cooldown, it should go to PENDING.
+        # We need to ensure cooldown is > 0. The previous patch context has exited.
+
+        # We assume default PARSE_COOLDOWN is 60s (defined in const.py).
+        # Since we just finished a parse, last_parse_time is set to now.
+
+        # delay=0 to ensure we don't wait 10s before checking cooldown logic
+        coordinator.request_parser_rescan(reason="Test Pending", delay=0)
         await hass.async_block_till_done()
 
-        # Verify the mock assertion passed (implicitly by no exception)
-        mock_parse.assert_called()
-
-    # 3. Transition back to IDLE: After update finishes
-    # Use a loop to wait for state change as it happens in background task
-    async def wait_for_idle():
-        while True:
-            state = hass.states.get(entity_id)
-            if state.state == STATE_IDLE:
-                return
-            await asyncio.sleep(0.1)
-
-    with contextlib.suppress(TimeoutError):
-        await asyncio.wait_for(wait_for_idle(), timeout=2.0)
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_IDLE, f"State after parsing should return to {STATE_IDLE}"
-
-    # 4. Transition to PENDING
-    # Now that we are IDLE, if we request another scan within cooldown, it should go to PENDING.
-    # We need to ensure cooldown is > 0. The previous patch context has exited.
-
-    # We assume default PARSE_COOLDOWN is 60s (defined in const.py).
-    # Since we just finished a parse, last_parse_time is set to now.
-
-    # delay=0 to ensure we don't wait 10s before checking cooldown logic
-    coordinator.request_parser_rescan(reason="Test Pending", delay=0)
-    await hass.async_block_till_done()
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_PENDING, f"State should be {STATE_PENDING} when requesting scan inside cooldown"
+        state = hass.states.get(entity_id)
+        assert state.state == STATE_PENDING, f"State should be {STATE_PENDING} when requesting scan inside cooldown"
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
 
 
 async def test_status_sensor_safe_mode(hass: HomeAssistant):
@@ -118,7 +122,7 @@ async def test_status_sensor_safe_mode(hass: HomeAssistant):
         # Initialize integration
         # Pass CONF_INCLUDED_FOLDERS=None to prevent async_init_integration from changing hass.config.config_dir
         # so that our lock file remains in the correct place.
-        await async_init_integration(hass, add_params={CONF_INCLUDED_FOLDERS: None})
+        config_entry = await async_init_integration(hass, add_params={CONF_INCLUDED_FOLDERS: None})
 
         # Get the sensor entity ID dynamically
         entity_registry = list(er.async_get(hass).entities.values())
@@ -134,3 +138,6 @@ async def test_status_sensor_safe_mode(hass: HomeAssistant):
     finally:
         # Cleanup if test fails
         Path(lock_path).unlink(missing_ok=True)
+        if config_entry:
+            await hass.config_entries.async_unload(config_entry.entry_id)
+            await hass.async_block_till_done()

--- a/tests/tests/test_ui_defaults.py
+++ b/tests/tests/test_ui_defaults.py
@@ -26,33 +26,37 @@ async def test_options_flow_missing_key_behavior(hass: HomeAssistant):
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    # Initialize options flow
-    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    try:
+        # Initialize options flow
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "init"
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "init"
 
-    # Check the schema description (suggested values)
-    # The key CONF_LOG_OBFUSCATE should NOT be in suggested_values if missing from data
-    # OR if it is, it might be False/None depending on implementation.
-    # We want to prove that it is NOT True (which is our desired default).
-    
-    data_schema = result["data_schema"]
-    
-    # In vol.Schema, we can't easily inspect suggested values injected by add_suggested_values_to_schema
-    # effectively because it wraps the schema.
-    # However, HA's add_suggested_values_to_schema modifies the schema elements.
-    
-    # We can inspect the field.
-    # We need to find the field corresponding to CONF_LOG_OBFUSCATE
-    field = data_schema.schema[CONF_LOG_OBFUSCATE]
-    
-    # If no suggested value, it defaults to what?
-    # Ideally, we want the migration to have PUT the value in config_entry.data, 
-    # so add_suggested_values_to_schema would pick it up.
-    
-    # Since migration ran during setup, we expect config_entry.data to HAVE the key.
-    assert CONF_LOG_OBFUSCATE in config_entry.data
-    
-    # And it should be True (default)
-    assert config_entry.data.get(CONF_LOG_OBFUSCATE) is True
+        # Check the schema description (suggested values)
+        # The key CONF_LOG_OBFUSCATE should NOT be in suggested_values if missing from data
+        # OR if it is, it might be False/None depending on implementation.
+        # We want to prove that it is NOT True (which is our desired default).
+        
+        data_schema = result["data_schema"]
+        
+        # In vol.Schema, we can't easily inspect suggested values injected by add_suggested_values_to_schema
+        # effectively because it wraps the schema.
+        # However, HA's add_suggested_values_to_schema modifies the schema elements.
+        
+        # We can inspect the field.
+        # We need to find the field corresponding to CONF_LOG_OBFUSCATE
+        field = data_schema.schema[CONF_LOG_OBFUSCATE]
+        
+        # If no suggested value, it defaults to what?
+        # Ideally, we want the migration to have PUT the value in config_entry.data, 
+        # so add_suggested_values_to_schema would pick it up.
+        
+        # Since migration ran during setup, we expect config_entry.data to HAVE the key.
+        assert CONF_LOG_OBFUSCATE in config_entry.data
+        
+        # And it should be True (default)
+        assert config_entry.data.get(CONF_LOG_OBFUSCATE) is True
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/tests/test_zombie_unload.py
+++ b/tests/tests/test_zombie_unload.py
@@ -17,55 +17,61 @@ async def test_zombie_listener_resurrection(hass: HomeAssistant):
     # This will initialize the DB
     entry = await async_init_integration(hass)
     
-    # 2. Assert watchman_v2.db exists in the storage directory
-    db_path = Path(hass.config.path(".storage", DB_FILENAME))
-    assert db_path.exists(), "DB file should exist after setup"
+    try:
+        # 2. Assert watchman_v2.db exists in the storage directory
+        db_path = Path(hass.config.path(".storage", DB_FILENAME))
+        assert db_path.exists(), "DB file should exist after setup"
 
-    # 3. Call await hass.config_entries.async_unload(entry.entry_id)
-    unload_result = await hass.config_entries.async_unload(entry.entry_id)
-    assert unload_result is True, "Unload should succeed"
-    await hass.async_block_till_done()
+        # 3. Call await hass.config_entries.async_unload(entry.entry_id)
+        unload_result = await hass.config_entries.async_unload(entry.entry_id)
+        assert unload_result is True, "Unload should succeed"
+        await hass.async_block_till_done()
 
-    # 4. Assert watchman_v2.db does NOT exist (cleanup successful)
-    # The existing async_remove_entry logic handles this cleanup
-    # We trigger removal manually or via config flow, but here async_unload just stops the integration.
-    # However, if the user *removes* the entry, it deletes the file.
-    # But wait, the issue description says "cleanup successful" after unload.
-    # Standard Home Assistant unload does NOT delete data files. Only removing the entry does.
-    # Let's re-read the context: "the integration is initialized and immediately unloaded... recreating the deleted database".
-    # This implies the user might have removed it, or the test setup assumes cleanup.
-    # Let's verify if `async_unload_entry` deletes the DB. 
-    # Checking `__init__.py`: `async_unload_entry` does NOT delete the file. `async_remove_entry` does.
-    
-    # To faithfully reproduce the "Zombie Listener Resurrects Database after Unload" described:
-    # If the user *removes* the integration, `async_unload` is called first, then `async_remove`.
-    # `async_remove` deletes the file.
-    # BUT, the `EVENT_HOMEASSISTANT_STARTED` listener was registered in `setup`.
-    # If that listener fires AFTER removal, it calls `coordinator.request_parser_rescan` -> `_execute_parse` -> `_init_db` -> creates file.
-    
-    # So we must simulate REMOVAL.
-    await hass.config_entries.async_remove(entry.entry_id)
-    await hass.async_block_till_done()
-    
-    assert not db_path.exists(), "DB file should be deleted after removal"
+        # 4. Assert watchman_v2.db does NOT exist (cleanup successful)
+        # The existing async_remove_entry logic handles this cleanup
+        # We trigger removal manually or via config flow, but here async_unload just stops the integration.
+        # However, if the user *removes* the entry, it deletes the file.
+        # But wait, the issue description says "cleanup successful" after unload.
+        # Standard Home Assistant unload does NOT delete data files. Only removing the entry does.
+        # Let's re-read the context: "the integration is initialized and immediately unloaded... recreating the deleted database".
+        # This implies the user might have removed it, or the test setup assumes cleanup.
+        # Let's verify if `async_unload_entry` deletes the DB. 
+        # Checking `__init__.py`: `async_unload_entry` does NOT delete the file. `async_remove_entry` does.
+        
+        # To faithfully reproduce the "Zombie Listener Resurrects Database after Unload" described:
+        # If the user *removes* the integration, `async_unload` is called first, then `async_remove`.
+        # `async_remove` deletes the file.
+        # BUT, the `EVENT_HOMEASSISTANT_STARTED` listener was registered in `setup`.
+        # If that listener fires AFTER removal, it calls `coordinator.request_parser_rescan` -> `_execute_parse` -> `_init_db` -> creates file.
+        
+        # So we must simulate REMOVAL.
+        await hass.config_entries.async_remove(entry.entry_id)
+        await hass.async_block_till_done()
+        
+        assert not db_path.exists(), "DB file should be deleted after removal"
 
-    # 5. Trigger the start event: hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
-    # This is the leaked listener firing late
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
-    
-    # 6. Wait for background tasks
-    await hass.async_block_till_done()
-    
-    # The listener schedules a parse with a delay (default 30s).
-    # We must advance time to trigger it.
-    from pytest_homeassistant_custom_component.common import async_fire_time_changed
-    from homeassistant.util import dt as dt_util
-    from datetime import timedelta
-    
-    # Fast forward time past the default startup delay
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=60))
-    await hass.async_block_till_done()
+        # 5. Trigger the start event: hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        # This is the leaked listener firing late
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        
+        # 6. Wait for background tasks
+        await hass.async_block_till_done()
+        
+        # The listener schedules a parse with a delay (default 30s).
+        # We must advance time to trigger it.
+        from pytest_homeassistant_custom_component.common import async_fire_time_changed
+        from homeassistant.util import dt as dt_util
+        from datetime import timedelta
+        
+        # Fast forward time past the default startup delay
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=60))
+        await hass.async_block_till_done()
 
-    # 7. Assertion (Failure Condition): Check if watchman_v2.db exists again.
-    # If it exists, the zombie listener ran `async_on_home_assistant_started` which triggered DB creation.
-    assert not db_path.exists(), "Zombie listener resurrected the database file!"
+        # 7. Assertion (Failure Condition): Check if watchman_v2.db exists again.
+        # If it exists, the zombie listener ran `async_on_home_assistant_started` which triggered DB creation.
+        assert not db_path.exists(), "Zombie listener resurrected the database file!"
+    finally:
+        from homeassistant.config_entries import ConfigEntryState
+        if entry.state != ConfigEntryState.NOT_LOADED:
+            await hass.config_entries.async_unload(entry.entry_id)
+            await hass.async_block_till_done()


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Refactored integration tests to properly handle the lifecycle of the Watchman integration during test execution.

The changes involve:
- Wrapping test logic in `try...finally` blocks.
- Ensuring `hass.config_entries.async_unload(entry.entry_id)` is explicitly called in the `finally` block.
- Adding `await hass.async_block_till_done()` after service calls that trigger integration reloads to ensure side effects are processed before assertion/teardown.

## Motivation and Context

This change is required to fix flaky tests and "Lingering timer/task" errors appearing in the CI/CD pipeline.

Previously, tests initializing the integration did not strictly unload it upon completion. This caused background tasks (specifically `EntityPlatform` polling timers and Coordinator updates) to remain active in the event loop after the test finished, triggering `pytest` errors regarding lingering resources.

This fix ensures a clean environment state after every test, eliminating false negatives caused by resource leaks.

## How has this been tested?

All 123 tests passed successfully, confirming that the refactoring maintained existing functionality while improving test robustness.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
