### PR TITLE
fix: report service - removed opinionated default values for optional parameters

### DIFF
--- a/custom_components/watchman/services.yaml
+++ b/custom_components/watchman/services.yaml
@@ -1,53 +1,50 @@
 report:
-  name: Report
-  description: Run watchman report
-  fields:
-    parse_config:
-      example: true
-      default: false
-      required: false
-      selector:
-        boolean:
-    advanced_options:
-      collapsed: true
-      fields:
-        action:
-          example: "persistent_notification.create"
-          default: "persistent_notification.create"
-          required: false
-          advanced: true
-          selector:
-            text:
-        data:
-          example: "title: Watchman Report"
-          required: false
-          advanced: true
-        chunk_size:
-          example: 3500
-          default: 3500
-          required: false
-          advanced: true
-          selector:
-            number:
-              min: 0
-              max: 100000
-              mode: box
-        create_file:
-          example: true
-          default: true
-          required: false
-          selector:
-            boolean:
+    name: Report
+    description: Run watchman report
+    fields:
+        parse_config:
+            example: true
+            default: false
+            required: false
+            selector:
+                boolean:
+        advanced_options:
+            collapsed: true
+            fields:
+                action:
+                    example: "persistent_notification.create"
+                    required: false
+                    advanced: true
+                    selector:
+                        text:
+                data:
+                    example: "title: Watchman Report"
+                    required: false
+                    advanced: true
+                chunk_size:
+                    example: 3500
+                    required: false
+                    advanced: true
+                    selector:
+                        number:
+                            min: 0
+                            max: 100000
+                            mode: box
+                create_file:
+                    example: true
+                    default: true
+                    required: false
+                    selector:
+                        boolean:
 
 set_ignored_labels:
-  name: Set ignored labels
-  description: Overwrite the list of labels to ignore.
-  fields:
-    labels:
-      name: Labels
-      description: List of labels to ignore.
-      required: true
-      selector:
-        label:
-          multiple: true
-
+    name: Set ignored labels
+    description: Overwrite the list of labels to ignore.
+    fields:
+        labels:
+            name: Labels
+            description: List of labels to ignore.
+            required: true
+            selector:
+                label:
+                    multiple: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removed opinionated default values for report service action and chunk size.

## Motivation and Context

This PR removes the default values for the action **Send report as notification** and **Notification message chunk size** parameters in services.yaml.

Previously, these defaults caused an unnecessary persistent notification to appear immediately when a user ran the report. While these defaults were originally intended to demonstrate the service's capabilities, they often result in unwanted clutter for the average user.

With this change, the default behavior is cleaner. Power users can still manually configure these parameters in the "Advanced options" section if they require notifications.

## How has this been tested?

Automatic regression tests passed.

## Screenshots (if appropriate):

<img width="1218" height="589" alt="image" src="https://github.com/user-attachments/assets/fca75c60-2260-43ed-bcfe-ca7bd667f136" />


## Types of changes

- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
