### PR TITLE
fix: if an entity/service is referenced in multiple files, only one is reported

### DIFF
--- a/custom_components/watchman/utils/report.py
+++ b/custom_components/watchman/utils/report.py
@@ -209,14 +209,19 @@ def text_renderer(
 def fill(data: Any, width: int, extra: str | None = None) -> str:
     """Arrange data by table column width."""
     if data and isinstance(data, dict):
-        key, val = next(iter(data.items()))
-        out = f"{key}:{','.join([str(v) for v in val])}"
+        lines = []
+        for key, val in data.items():
+            lines.append(f"{key}:{','.join([str(v) for v in val])}")
+        out = "\n".join(lines)
     else:
         out = str(data) if not extra else f"{data} ('{extra}')"
 
-    return (
-        "\n".join([out.ljust(width) for out in wrap(out, width)]) if width > 0 else out
-    )
+    if width > 0:
+        wrapped_lines = []
+        for line in out.split("\n"):
+            wrapped_lines.extend(wrap(line, width))
+        return "\n".join([line.ljust(width) for line in wrapped_lines])
+    return out
 
 
 def get_columns_width(user_width: list[int] | None) -> list[int]:

--- a/tests/data/reports/test_multiple_files/file1.yaml
+++ b/tests/data/reports/test_multiple_files/file1.yaml
@@ -1,0 +1,7 @@
+automation:
+  - alias: "Automation 1"
+    trigger:
+      - platform: state
+        entity_id: sensor.missing_entity
+    action:
+      - service: script.missing_service

--- a/tests/data/reports/test_multiple_files/file2.yaml
+++ b/tests/data/reports/test_multiple_files/file2.yaml
@@ -1,0 +1,7 @@
+automation:
+  - alias: "Automation 2"
+    trigger:
+      - platform: state
+        entity_id: sensor.missing_entity
+    action:
+      - service: script.missing_service

--- a/tests/tests/test_report_multiple_files.py
+++ b/tests/tests/test_report_multiple_files.py
@@ -1,0 +1,80 @@
+"""Test report generation with multiple files for the same missing item."""
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from custom_components.watchman.const import (
+    CONF_IGNORED_STATES,
+    CONF_INCLUDED_FOLDERS,
+    CONF_REPORT_PATH,
+    CONF_SECTION_APPEARANCE_LOCATION,
+    DOMAIN,
+)
+import pytest
+from tests import async_init_integration
+
+
+# Mock stats to ensure deterministic output
+async def mock_stats(hass, start_time):
+    """Mock function for report stats."""
+    return ("01 Jan 2026 12:00:00", 1.23, 5, 0.1234)
+
+@patch("custom_components.watchman.utils.report.parsing_stats", new=mock_stats)
+@pytest.mark.asyncio
+async def test_report_multiple_files(hass, new_test_data_dir, tmp_path):
+    """Test that all files are reported when an item is in multiple files."""
+    # Define source config directory
+    config_dir = str(Path(new_test_data_dir) / "reports" / "test_multiple_files")
+
+    # Mock hass.config.config_dir to the source dir so relative paths are calculated correctly
+    hass.config.config_dir = config_dir
+
+    # Mock hass.config.path to redirect .storage/watchman.db to tmp_path
+    def mock_path_side_effect(*args):
+        return str(tmp_path.joinpath(*args))
+
+    hass.config.path = MagicMock(side_effect=mock_path_side_effect)
+
+    report_file = tmp_path / "watchman_report.txt"
+
+    # Initialize integration pointing to our dedicated folder
+    config_entry = await async_init_integration(
+        hass,
+        add_params={
+            CONF_INCLUDED_FOLDERS: config_dir,
+            CONF_SECTION_APPEARANCE_LOCATION: {
+                CONF_REPORT_PATH: str(report_file),
+            },
+            CONF_IGNORED_STATES: [], # Report everything
+        },
+    )
+
+    try:
+        # Run report
+        await hass.services.async_call(DOMAIN, "report")
+        await hass.async_block_till_done()
+
+        # Verify report created
+        assert report_file.exists()
+
+        # Read content
+        content = report_file.read_text(encoding="utf-8")
+
+        # Check if both files are mentioned in the report
+        assert "file1.yaml" in content
+        assert "file2.yaml" in content
+
+        # Verify that both files are associated with the missing entity
+        # We check the block of text around the missing entity
+        entity_section = content[content.find("sensor.missing_entity") : content.find("-==", content.find("sensor.missing_entity"))]
+        assert "file1.yaml:5" in entity_section
+        assert "file2.yaml:5" in entity_section
+
+        # Verify that both files are associated with the missing service
+        service_section = content[content.find("script.missing_service") : content.find("-==", content.find("script.missing_service"))]
+        assert "file1.yaml:7" in service_section
+        assert "file2.yaml:7" in service_section
+
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()


### PR DESCRIPTION
## Description




## Description

This PR addresses an issue where a flagged entity found in multiple files was only being reported against a single file. The report generation logic has been updated to correctly aggregate and list all file paths where the entity is present.

### Related Issues
* **Fixes #198**
* **Closes #199**

## Motivation and Context

This PR provides an updated implementation of the fix originally proposed by Rob in #199. Since the watchman codebase has evolved significantly since that PR was opened, a fresh implementation was required to align with the current architecture. 

Huge thanks to Rob for catching this bug, opening the issue, and providing the initial solution! 

## How has this been tested?

Automatic tests passed, new tests has been added.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
