### PR TITLE
fix: ignore entries within jinja comments

### DIFF
--- a/tests/tests/test_jinja_comments.py
+++ b/tests/tests/test_jinja_comments.py
@@ -1,0 +1,101 @@
+"""Test parsing of Jinja2 comments."""
+import asyncio
+from pathlib import Path
+import pytest
+from custom_components.watchman.utils.parser_core import WatchmanParser
+
+@pytest.fixture
+def parser_client(tmp_path):
+    """Create a WatchmanParser instance with a temporary database."""
+    db_path = tmp_path / "watchman.db"
+    client = WatchmanParser(str(db_path))
+    return client
+
+def test_jinja_comments_ignored(parser_client, tmp_path):
+    """Test that entities inside Jinja2 comments are ignored."""
+    yaml_content = """
+sensor:
+  - platform: template
+    sensors:
+      test_sensor:
+        value_template: >
+          {# sensor.should_be_ignored #}
+          {{ states('sensor.valid_entity') }}
+          {#
+            sensor.ignored_one
+            sensor.ignored_two
+          #}
+          {{ states('sensor.another_valid_entity') }}
+"""
+    test_file = tmp_path / "test_jinja_comments.yaml"
+    test_file.write_text(yaml_content, encoding="utf-8")
+    
+    # Parse the directory
+    entities, services, _, _, _, _ = asyncio.run(parser_client.async_parse(str(tmp_path), []))
+    
+    # Assertions
+    assert "sensor.valid_entity" in entities, "Should find valid entity 1"
+    assert "sensor.another_valid_entity" in entities, "Should find valid entity 2"
+    
+    assert "sensor.should_be_ignored" not in entities, "Should ignore single-line comment"
+    assert "sensor.ignored_one" not in entities, "Should ignore multi-line comment entity 1"
+    assert "sensor.ignored_two" not in entities, "Should ignore multi-line comment entity 2"
+
+def test_jinja_comments_line_numbers(parser_client, tmp_path):
+    """Test that line numbers are preserved when ignoring comments."""
+    yaml_content = """
+action: |
+  {#
+    sensor.ignored_one
+    sensor.ignored_two
+  #}
+  service: light.turn_on
+  target:
+    entity_id: light.valid_entity
+"""
+    # Line 1: empty (yaml starts at 2)
+    # Line 2: action: |
+    # Line 3:   {#
+    # Line 4:     sensor.ignored_one
+    # Line 5:     sensor.ignored_two
+    # Line 6:   #}
+    # Line 7:   service: light.turn_on
+    # Line 8:   target:
+    # Line 9:     entity_id: light.valid_entity
+
+    test_file = tmp_path / "test_line_numbers.yaml"
+    test_file.write_text(yaml_content, encoding="utf-8")
+
+    # Run the parser to get detailed items
+    # We need access to the found items directly, so we use async_scan then query DB or use get_found_items
+    asyncio.run(parser_client.async_scan(str(tmp_path), []))
+
+    items = parser_client.get_found_items(item_type='all')
+
+    # Helper to find item
+    def find_item(entity_id):
+        for item in items:
+            # item structure: (entity_id, path, line, item_type, parent_type, parent_alias, parent_id)
+            if item[0] == entity_id:
+                return item
+        return None
+
+    # Verify ignored
+    assert find_item("sensor.ignored_one") is None
+    assert find_item("sensor.ignored_two") is None
+
+    # Verify valid service
+    # Structure: (entity_id, path, line, item_type, ...)
+    service_item = find_item("light.turn_on")
+    assert service_item is not None
+    
+    # light.turn_on is on line 7 (1-based).
+    # yaml_loader.py returns 1-based line numbers (start_mark.line + 1).
+    assert service_item[2] == 7, f"Expected line 7 (1-based), got {service_item[2]}"
+    
+    # Verify valid entity
+    entity_item = find_item("light.valid_entity")
+    assert entity_item is not None
+    # light.valid_entity is on line 9 (1-based).
+    assert entity_item[2] == 9, f"Expected line 9 (1-based), got {entity_item[2]}"
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduces a pre-parsing sanitization step to safely ignore Jinja2 comments (`{# ... #}`) within string values before they are evaluated by the regex scanners. Closes #275.

Instead of completely stripping the commented text, the implementation uses a combined approach: it matches the comment blocks and uses a substitution callback to replace the entire block with an equivalent number of newline characters (`\n`). This sanitization occurs specifically within the `isinstance(data, str)` block in `_recursive_search`, right before passing the cleaned string to `_yield_template_lines` and `_scan_string_for_entities`.

## Motivation and Context

Previously, the parser would incorrectly scan inside Jinja2 comments, leading to false-positive entity and service detections when users commented out template blocks in their YAML configurations.

The primary challenge in fixing this was preserving the parser's accurate line numbering. A naive regex replacement (e.g., `re.sub(..., "", text)`) would physically collapse the string. If a 5-line comment was removed, all subsequent entities in that block would shift upwards, resulting in incorrect `line_no` reports in the final output.

By replacing the comment contents with empty newlines, we effectively hide the text from the `_ENTITY_PATTERN` and `_SERVICE_PATTERN` while maintaining the exact vertical footprint of the original string. This guarantees that line offsets calculated during parsing remain perfectly aligned with the original source file.

## How has this been tested?

Existing automatic tests passed, new tests added.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
