### PR TITLE
fix: assign `notification_id` for `persistent_notification` only

### DIFF
--- a/custom_components/watchman/utils/report.py
+++ b/custom_components/watchman/utils/report.py
@@ -315,7 +315,8 @@ async def async_report_to_notification(
     action = ".".join(action_str.split(".")[1:])
 
     data = {} if service_data is None else service_data.copy()
-    if "notification_id" not in data:
+    # only inject notification_id for persistent_notification service
+    if domain == "persistent_notification" and "notification_id" not in data:
         data["notification_id"] = "watchman_report"
 
     _LOGGER.debug(f"SERVICE_DATA {data}")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Restricted the default `notification_id` injection in `async_report_to_notification` to only apply when the target domain is `persistent_notification`.  Closes #279.

## Motivation and Context
This fixes a regression introduced in #203. Previously, the default `notification_id: watchman_report` was blindly appended to the `service_data` of *all* report notification calls. 

Because Home Assistant enforces strict schema validation for service calls, passing `notification_id` to services that do not support it in their schema (such as `notify.apprise`, `notify.mobile_app`, or `notify.telegram`) resulted in a `ServiceValidationError` (`extra keys not allowed @ data['notification_id']`). 

By checking the domain first, we maintain the ability to easily dismiss Watchman's persistent notifications without breaking compatibility with third-party notification integrations.

## How has this been tested?

Existing automatic tests passed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
