### PR TITLE
feat: option to bypass max file size limit for parser

### DIFF
--- a/custom_components/watchman/__init__.py
+++ b/custom_components/watchman/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.loader import async_get_integration
 
 from .const import (
     CONF_COLUMNS_WIDTH,
+    CONF_ENFORCE_FILE_SIZE,
     CONF_FRIENDLY_NAMES,
     CONF_HEADER,
     CONF_IGNORED_FILES,
@@ -308,6 +309,11 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             _LOGGER.info("Migrating Watchman entry to minor version 4")
             # Do not initialize ignored_labels here to allow text entity to restore state lazily
             current_minor = 4
+
+        if current_minor < 5:
+            _LOGGER.info("Migrating Watchman entry to minor version 5")
+            data[CONF_ENFORCE_FILE_SIZE] = DEFAULT_OPTIONS.get(CONF_ENFORCE_FILE_SIZE, True)
+            current_minor = 5
 
         if current_minor != config_entry.minor_version:
             hass.config_entries.async_update_entry(

--- a/custom_components/watchman/config_flow.py
+++ b/custom_components/watchman/config_flow.py
@@ -17,6 +17,7 @@ from homeassistant.helpers import config_validation as cv, selector
 
 from .const import (
     CONF_COLUMNS_WIDTH,
+    CONF_ENFORCE_FILE_SIZE,
     CONF_EXCLUDE_DISABLED_AUTOMATION,
     CONF_FRIENDLY_NAMES,
     CONF_HEADER,
@@ -36,6 +37,7 @@ from .const import (
     MONITORED_STATES,
 )
 from .utils.logger import _LOGGER
+from .utils.parser_const import MAX_FILE_SIZE
 from .utils.utils import async_is_valid_path, get_val
 
 INCLUDED_FOLDERS_SCHEMA = vol.Schema(vol.All(cv.ensure_list, [cv.string]))
@@ -71,6 +73,9 @@ def _get_data_schema() -> vol.Schema:
             ): cv.boolean,
             vol.Optional(
                 CONF_LOG_OBFUSCATE,
+            ): cv.boolean,
+            vol.Optional(
+                CONF_ENFORCE_FILE_SIZE,
             ): cv.boolean,
             vol.Required(CONF_SECTION_APPEARANCE_LOCATION): data_entry_flow.section(
                 vol.Schema(
@@ -212,6 +217,7 @@ class OptionsFlowHandler(OptionsFlow):
             )
             placeholders = dict(placeholders)
             placeholders["url"] = "https://github.com/dummylabs/thewatchman#configuration"
+            placeholders["max_size_kb"] = str(int(MAX_FILE_SIZE / 1024))
             return self.async_show_form(
                 step_id="init",
                 data_schema=self.add_suggested_values_to_schema(
@@ -229,6 +235,7 @@ class OptionsFlowHandler(OptionsFlow):
                 self.config_entry.data,
             ),
             description_placeholders={
-                "url": "https://github.com/dummylabs/thewatchman#configuration"
+                "url": "https://github.com/dummylabs/thewatchman#configuration",
+                "max_size_kb": str(int(MAX_FILE_SIZE / 1024)),
             },
         )

--- a/custom_components/watchman/const.py
+++ b/custom_components/watchman/const.py
@@ -14,7 +14,7 @@ DOMAIN_DATA = f"{DOMAIN}_data"
 
 
 CONFIG_ENTRY_VERSION = 2
-CONFIG_ENTRY_MINOR_VERSION = 4
+CONFIG_ENTRY_MINOR_VERSION = 5
 
 DEFAULT_REPORT_FILENAME = f"{DOMAIN}_report.txt"
 DB_FILENAME = f"{DOMAIN}_v2.db"
@@ -70,6 +70,7 @@ CONF_STARTUP_DELAY = "startup_delay"
 CONF_FRIENDLY_NAMES = "friendly_names"
 CONF_LOG_OBFUSCATE = "log_obfuscate"
 CONF_IGNORED_LABELS = "ignored_labels"
+CONF_ENFORCE_FILE_SIZE = "enforce_file_size"
 # configuration parameters allowed in watchman.report service data
 CONF_ALLOWED_SERVICE_PARAMS = [
     CONF_SERVICE_NAME,
@@ -138,6 +139,7 @@ DEFAULT_OPTIONS = {
     CONF_IGNORED_FILES: "",
     CONF_STARTUP_DELAY: 30,
     CONF_LOG_OBFUSCATE: True,
+    CONF_ENFORCE_FILE_SIZE: True,
     CONF_SECTION_APPEARANCE_LOCATION: {
         CONF_HEADER: "-== Watchman Report ==-",
         CONF_REPORT_PATH: "",

--- a/custom_components/watchman/hub.py
+++ b/custom_components/watchman/hub.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from .const import BUNDLED_IGNORED_ITEMS, CONF_IGNORED_ITEMS
+from .const import BUNDLED_IGNORED_ITEMS, CONF_ENFORCE_FILE_SIZE, CONF_IGNORED_ITEMS
 from .utils.logger import _LOGGER
 from .utils.parser_core import ParseResult, WatchmanParser, get_domains
 from .utils.utils import get_config
@@ -112,7 +112,7 @@ class WatchmanHub:
         return {"entities": entities, "services": services}
 
     async def async_parse(
-        self, ignored_files: list[str], *, force: bool = False
+        self, ignored_files: list[str]
     ) -> ParseResult | None:
         """Asynchronous wrapper for the parse method."""
         if self._is_scanning:
@@ -122,6 +122,7 @@ class WatchmanHub:
         self._is_scanning = True
         try:
             custom_domains = get_domains(self.hass)
+            enforce_file_size = get_config(self.hass, CONF_ENFORCE_FILE_SIZE, True)
 
             (
                 _entities,
@@ -133,9 +134,9 @@ class WatchmanHub:
             ) = await self._parser.async_parse(
                 self.hass.config.config_dir,
                 ignored_files,
-                force=force,
                 custom_domains=custom_domains,
                 base_path=self.hass.config.config_dir,
+                enforce_file_size=enforce_file_size,
             )
 
             self.cached_items = {}

--- a/custom_components/watchman/translations/en.json
+++ b/custom_components/watchman/translations/en.json
@@ -25,7 +25,8 @@
                     "ignored_labels": "Ignored labels:",
                     "check_lovelace": "Parse UI controlled dashboards",
                     "startup_delay": "Startup delay for watchman sensors initialization",
-                    "log_obfuscate": "Obfuscate sensitive data in logs"
+                    "log_obfuscate": "Obfuscate sensitive data in logs",
+                    "enforce_file_size": "Enforce max file size limit"
                 },
                 "data_description": {
                     "included_folders": "Comma-separated list of folders where watchman should look for config files",
@@ -34,7 +35,8 @@
                     "ignored_files": "Comma-separated list of config files excluded from tracking",
                     "ignored_labels": "Use labels to exclude entities from tracking",
                     "log_obfuscate": "Whether to mask entity and action names in debug logs for privacy",
-                    "exclude_disabled_automation": "Exclude entities used only by disabled automations"
+                    "exclude_disabled_automation": "Exclude entities used only by disabled automations",
+                    "enforce_file_size": "Disable this to parse files larger than {max_size_kb}KB. This might increase parsing time and memory usage."
                 },
                 "sections": {
                     "appearance_location_options": {

--- a/custom_components/watchman/utils/utils.py
+++ b/custom_components/watchman/utils/utils.py
@@ -15,6 +15,7 @@ from homeassistant.helpers import entity_registry as er
 
 from ..const import (
     CONF_COLUMNS_WIDTH,
+    CONF_ENFORCE_FILE_SIZE,
     CONF_EXCLUDE_DISABLED_AUTOMATION,
     CONF_FRIENDLY_NAMES,
     CONF_HEADER,
@@ -111,6 +112,7 @@ def get_config(hass: HomeAssistant, key: str, default: Any | None = None) -> Any
         CONF_EXCLUDE_DISABLED_AUTOMATION,
         CONF_STARTUP_DELAY,
         CONF_LOG_OBFUSCATE,
+        CONF_ENFORCE_FILE_SIZE,
     ]:
         return get_val(entry.data, key)
 

--- a/tests/tests/test_file_size_limit.py
+++ b/tests/tests/test_file_size_limit.py
@@ -1,0 +1,223 @@
+"""Test enforce_file_size option and parser behavior."""
+import asyncio
+import os
+import sqlite3
+import pytest
+from unittest.mock import patch, MagicMock
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+from homeassistant import data_entry_flow
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.watchman.const import (
+    DOMAIN,
+    CONF_ENFORCE_FILE_SIZE,
+    CONF_STARTUP_DELAY,
+    CONF_SECTION_APPEARANCE_LOCATION,
+    CONF_REPORT_PATH,
+    CONF_HEADER,
+    CONF_COLUMNS_WIDTH,
+    DB_FILENAME,
+)
+from custom_components.watchman.utils.parser_const import MAX_FILE_SIZE
+
+# Create a file slightly larger than MAX_FILE_SIZE
+LARGE_FILE_SIZE = MAX_FILE_SIZE + 1024
+
+@pytest.fixture
+def large_file(hass):
+    """Create a large dummy configuration file."""
+    config_dir = hass.config.config_dir
+    file_path = os.path.join(config_dir, "large_config.yaml")
+    
+    # Content that is valid YAML but large
+    # We include a reference to an entity that watchman should find
+    content = """
+test_reference:
+  - service: light.turn_on
+    entity_id: light.large_file_test_light
+"""
+    padding = "# " + ("x" * 100) + "\n"
+    
+    # Calculate how many lines we need to exceed MAX_FILE_SIZE
+    # 3 lines of content (~60 bytes) + padding lines (~103 bytes each)
+    target_size = LARGE_FILE_SIZE
+    current_size = len(content.encode('utf-8'))
+    
+    while current_size < target_size:
+        content += padding
+        current_size += len(padding.encode('utf-8'))
+        
+    with open(file_path, "w") as f:
+        f.write(content)
+        
+    yield file_path
+    
+    # Cleanup
+    if os.path.exists(file_path):
+        os.remove(file_path)
+
+async def _get_processed_files(hass):
+    """Helper to query processed_files table."""
+    db_path = hass.config.path(".storage", DB_FILENAME)
+    if not os.path.exists(db_path):
+        return []
+        
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute("SELECT path FROM processed_files")
+    rows = cursor.fetchall()
+    conn.close()
+    return [row[0] for row in rows]
+
+async def _get_found_items(hass, entity_id):
+    """Helper to query found_items table."""
+    db_path = hass.config.path(".storage", DB_FILENAME)
+    if not os.path.exists(db_path):
+        return []
+        
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute("SELECT entity_id FROM found_items WHERE entity_id = ?", (entity_id,))
+    rows = cursor.fetchall()
+    conn.close()
+    return [row[0] for row in rows]
+
+@pytest.mark.asyncio
+async def test_options_flow_enforce_file_size(hass: HomeAssistant):
+    """Test that enforce_file_size can be toggled via OptionsFlow."""
+    
+    # Initialize Config Entry with default (True)
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="test_entry_options",
+        version=2,
+        minor_version=5,
+        data={
+            CONF_ENFORCE_FILE_SIZE: True,
+            CONF_STARTUP_DELAY: 0
+        }
+    )
+    config_entry.add_to_hass(hass)
+    
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    
+    with patch("custom_components.watchman.config_flow.async_is_valid_path", return_value=True):
+        try:
+            # Start Options Flow
+            result = await hass.config_entries.options.async_init(config_entry.entry_id)
+            assert result["type"] == data_entry_flow.FlowResultType.FORM
+            assert result["step_id"] == "init"
+            
+            # Check if option is present in schema
+            schema = result["data_schema"]
+            assert CONF_ENFORCE_FILE_SIZE in schema.schema
+            
+            # Change option to False
+            user_input = {
+                CONF_ENFORCE_FILE_SIZE: False,
+                CONF_STARTUP_DELAY: 30,
+                CONF_SECTION_APPEARANCE_LOCATION: {
+                    CONF_REPORT_PATH: "/config/report.txt",
+                    CONF_HEADER: "-== Watchman Report ==-",
+                    CONF_COLUMNS_WIDTH: "30, 8, 60"
+                }
+            }
+            
+            result = await hass.config_entries.options.async_configure(
+                result["flow_id"], user_input=user_input
+            )
+            await hass.async_block_till_done()
+            
+            assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+            
+            # Verify persistence
+            assert config_entry.data[CONF_ENFORCE_FILE_SIZE] is False
+            
+        finally:
+            await hass.config_entries.async_unload(config_entry.entry_id)
+            await hass.async_block_till_done()
+
+@pytest.mark.asyncio
+async def test_parser_file_size_limit_end_to_end(hass: HomeAssistant, large_file):
+    """Test end-to-end parser behavior with enforce_file_size toggle."""
+    
+    with patch("custom_components.watchman.DEFAULT_DELAY", 0), \
+         patch("custom_components.watchman.coordinator.PARSE_COOLDOWN", 0):
+        # Phase 1: Default Behavior (enforce_file_size = True)
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            unique_id="test_entry_e2e",
+            version=2,
+            minor_version=5,
+            data={
+                CONF_ENFORCE_FILE_SIZE: True,
+                CONF_STARTUP_DELAY: 0,
+                # We need to specify ignored_files to match default behavior or it might be missing
+                "ignored_files": "" 
+            }
+        )
+        config_entry.add_to_hass(hass)
+        
+        # Start integration
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        
+        coordinator = hass.data[DOMAIN][config_entry.entry_id]
+        
+        # Force initial parse (simulating startup scan)
+        await coordinator.async_force_parse()
+        await hass.async_block_till_done()
+        
+        # Verify file is ignored (NOT in processed_files)
+        processed_files = await _get_processed_files(hass)
+        # The path stored in DB is relative to config dir
+        large_file_rel = os.path.basename(large_file)
+        assert large_file_rel not in processed_files, "Large file should be ignored when enforce_file_size is True"
+        
+        # Phase 2: Toggle OFF (enforce_file_size = False)
+        # Update options via ConfigEntry update (simulating OptionsFlow result)
+        hass.config_entries.async_update_entry(
+            config_entry, 
+            data={**config_entry.data, CONF_ENFORCE_FILE_SIZE: False}
+        )
+        await hass.async_block_till_done()
+        
+        # Wait for background parser task triggered by reload
+        coordinator = hass.data[DOMAIN][config_entry.entry_id]
+        if coordinator._parse_task:
+            await coordinator._parse_task
+        await hass.async_block_till_done()
+        
+        # Verify file is processed (IS in processed_files)
+        processed_files = await _get_processed_files(hass)
+        assert large_file_rel in processed_files, "Large file should be processed when enforce_file_size is False"
+        
+        # Verify entities found
+        found_items = await _get_found_items(hass, "light.large_file_test_light")
+        assert "light.large_file_test_light" in found_items, "Entity in large file should be found"
+        
+        # Phase 3: Toggle ON (enforce_file_size = True)
+        hass.config_entries.async_update_entry(
+            config_entry, 
+            data={**config_entry.data, CONF_ENFORCE_FILE_SIZE: True}
+        )
+        await hass.async_block_till_done()
+        
+        # Wait for background parser task triggered by reload
+        coordinator = hass.data[DOMAIN][config_entry.entry_id]
+        if coordinator._parse_task:
+            await coordinator._parse_task
+        await hass.async_block_till_done()
+        
+        # Verify file is evicted (NOT in processed_files)
+        processed_files = await _get_processed_files(hass)
+        assert large_file_rel not in processed_files, "Large file should be evicted when enforce_file_size is True"
+        
+        # Verify entities removed
+        found_items = await _get_found_items(hass, "light.large_file_test_light")
+        assert "light.large_file_test_light" not in found_items, "Entity from large file should be removed"
+        
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/tests/test_options_flow.py
+++ b/tests/tests/test_options_flow.py
@@ -1,15 +1,17 @@
 """Test Watchman Options Flow."""
 from unittest.mock import patch, MagicMock
 import pytest
+
 from custom_components.watchman.const import (
-    DOMAIN, 
+    DOMAIN,
     CONF_IGNORED_LABELS,
     CONF_STARTUP_DELAY,
     CONF_SECTION_APPEARANCE_LOCATION,
     CONF_REPORT_PATH,
     CONF_HEADER,
-    CONF_COLUMNS_WIDTH
+    CONF_COLUMNS_WIDTH,
 )
+from custom_components.watchman.utils.parser_const import MAX_FILE_SIZE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -17,24 +19,24 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 @pytest.mark.asyncio
 async def test_options_flow_labels(hass: HomeAssistant):
     """Test options flow label selection."""
-    
+
     # 1. Setup Label Registry
     mock_registry = MagicMock()
     # Mock list of labels
     label1 = MagicMock()
     label1.label_id = "test"
     label1.name = "Test Label"
-    
+
     label2 = MagicMock()
     label2.label_id = "private"
     label2.name = "Private Label"
-    
+
     mock_registry.async_list_labels.return_value = [label1, label2]
-    
+
     with patch("homeassistant.helpers.label_registry.async_get", return_value=mock_registry), \
          patch("custom_components.watchman.config_flow.async_is_valid_path", return_value=True), \
          patch("custom_components.watchman.DEFAULT_DELAY", 0):
-        
+
         # Initialize Config Entry
         config_entry = MockConfigEntry(
             domain=DOMAIN,
@@ -47,25 +49,29 @@ async def test_options_flow_labels(hass: HomeAssistant):
             }
         )
         config_entry.add_to_hass(hass)
-        
+
         # Setup integration
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-        
+
         try:
             # 2. Interaction
             result = await hass.config_entries.options.async_init(config_entry.entry_id)
-            
+
             assert result["type"] == FlowResultType.FORM
             assert result["step_id"] == "init"
-            
+
             # Check schema has the key
             schema = result["data_schema"]
             assert CONF_IGNORED_LABELS in schema.schema
-            
+
+            # Check description placeholders
+            assert "max_size_kb" in result["description_placeholders"]
+            assert result["description_placeholders"]["max_size_kb"] == str(MAX_FILE_SIZE//1024)
+
             # Simulate user selecting "test" and "private"
             # We must provide all required fields as per schema
-            
+
             user_input = {
                 CONF_IGNORED_LABELS: ["test", "private"],
                 CONF_STARTUP_DELAY: 30,
@@ -75,19 +81,19 @@ async def test_options_flow_labels(hass: HomeAssistant):
                     CONF_COLUMNS_WIDTH: "30, 8, 60"
                 }
             }
-            
+
             # 3. Assertion
             # We need to mock async_update_entry on hass.config_entries because the real one updates the entry object
             # but we want to verify the call or just check the entry object afterwards.
             # The real async_update_entry updates the entry in memory.
-            
+
             result = await hass.config_entries.options.async_configure(
                 result["flow_id"], user_input=user_input
             )
             await hass.async_block_till_done() # Wait for possible reload
-            
+
             assert result["type"] == FlowResultType.CREATE_ENTRY
-            
+
             # Verify persistence
             assert config_entry.data[CONF_IGNORED_LABELS] == ["test", "private"]
         finally:

--- a/tests/tests/test_parser_file_size.py
+++ b/tests/tests/test_parser_file_size.py
@@ -34,5 +34,5 @@ def test_large_file_skipped(parser_client, tmp_path, caplog):
     assert "sensor.valid" in entities
 
     # Verify large file skipped (log message)
-    assert "is too large" in caplog.text
+    assert "skipped due to size" in caplog.text
     assert str(large_file) in caplog.text

--- a/uv.lock
+++ b/uv.lock
@@ -1263,11 +1263,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.24.0"
+version = "3.24.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/00/cd/fa3ab025a8f9772e8a9146d8fd8eef6d62649274d231ca84249f54a0de4a/filelock-3.24.0.tar.gz", hash = "sha256:aeeab479339ddf463a1cdd1f15a6e6894db976071e5883efc94d22ed5139044b", size = 37166, upload-time = "2026-02-14T16:05:28.723Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/a8/dae62680be63cbb3ff87cfa2f51cf766269514ea5488479d42fec5aa6f3a/filelock-3.24.2.tar.gz", hash = "sha256:c22803117490f156e59fafce621f0550a7a853e2bbf4f87f112b11d469b6c81b", size = 37601, upload-time = "2026-02-16T02:50:45.614Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/dd/d7e7f4f49180e8591c9e1281d15ecf8e7f25eb2c829771d9682f1f9fe0c8/filelock-3.24.0-py3-none-any.whl", hash = "sha256:eebebb403d78363ef7be8e236b63cc6760b0004c7464dceaba3fd0afbd637ced", size = 23977, upload-time = "2026-02-14T16:05:27.578Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/04/a94ebfb4eaaa08db56725a40de2887e95de4e8641b9e902c311bfa00aa39/filelock-3.24.2-py3-none-any.whl", hash = "sha256:667d7dc0b7d1e1064dd5f8f8e80bdac157a6482e8d2e02cd16fd3b6b33bd6556", size = 24152, upload-time = "2026-02-16T02:50:44Z" },
 ]
 
 [[package]]
@@ -2575,11 +2575,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.9.1"
+version = "4.9.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/d5/763666321efaded11112de8b7a7f2273dd8d1e205168e73c334e54b0ab9a/platformdirs-4.9.1.tar.gz", hash = "sha256:f310f16e89c4e29117805d8328f7c10876eeff36c94eac879532812110f7d39f", size = 28392, upload-time = "2026-02-14T21:02:44.973Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/04/fea538adf7dbbd6d186f551d595961e564a3b6715bdf276b477460858672/platformdirs-4.9.2.tar.gz", hash = "sha256:9a33809944b9db043ad67ca0db94b14bf452cc6aeaac46a88ea55b26e2e9d291", size = 28394, upload-time = "2026-02-16T03:56:10.574Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/77/e8c95e95f1d4cdd88c90a96e31980df7e709e51059fac150046ad67fac63/platformdirs-4.9.1-py3-none-any.whl", hash = "sha256:61d8b967d34791c162d30d60737369cbbd77debad5b981c4bfda1842e71e0d66", size = 21307, upload-time = "2026-02-14T21:02:43.492Z" },
+    { url = "https://files.pythonhosted.org/packages/48/31/05e764397056194206169869b50cf2fee4dbbbc71b344705b9c0d878d4d8/platformdirs-4.9.2-py3-none-any.whl", hash = "sha256:9170634f126f8efdae22fb58ae8a0eaa86f38365bc57897a6c4f781d1f5875bd", size = 21168, upload-time = "2026-02-16T03:56:08.891Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a new configuration toggle `enforce_file_size` to the integration's OptionsFlow. 
* By default, the parser enforces the `MAX_FILE_SIZE` limit (500KB) and safely ignores oversized files, as it did previously.
* When the user disables this toggle in the integration options, the parser bypasses the size check and processes files of any size. Related to #265.

## Motivation and Context
This change addresses user complaints regarding the hardcoded 500KB file size limit. While the limit serves as a necessary safeguard against memory and performance issues during parsing, power users with exceptionally large or complex configuration files needed an "escape hatch". 

This PR provides a flexible solution: it keeps the integration safe and performant by default, but gives advanced users the control they need to process massive configurations at their own discretion.

## How has this been tested?

Existing tests passed, added comprehensive E2E tests to verify cache eviction and parsing behavior when the toggle is flipped.


## Screenshots (if appropriate):

<img width="554" height="98" alt="image" src="https://github.com/user-attachments/assets/f97be8e0-b5e3-45da-bcbc-f0356d6d81f4" />

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.