### PR TITLE
ref: remove unused return values from async_parse

### DIFF
--- a/cli/parser.py
+++ b/cli/parser.py
@@ -103,10 +103,10 @@ def main():
 
     client = WatchmanParser(args.db_path)
 
-    logging.info(f"Calling client.scan with: root_path={root_path}, ignored_files={ignored_files}, force={args.force}, base_path={root_path}")
+    logging.info(f"Calling client.scan with: root_path={root_path}, ignored_files={ignored_files}, ignore_mtime={args.force}, base_path={root_path}")
     # We call scan directly. Logic for configuration change detection is inside WatchmanParser.scan
     import asyncio
-    asyncio.run(client.async_scan(root_path, ignored_files, force=args.force, base_path=root_path))
+    asyncio.run(client.async_scan(root_path, ignored_files, ignore_mtime=args.force, base_path=root_path))
 
     # Output results matching original format
     if not args.no_files:

--- a/custom_components/watchman/hub.py
+++ b/custom_components/watchman/hub.py
@@ -124,14 +124,7 @@ class WatchmanHub:
             custom_domains = get_domains(self.hass)
             enforce_file_size = get_config(self.hass, CONF_ENFORCE_FILE_SIZE, True)
 
-            (
-                _entities,
-                _services,
-                _files_parsed,
-                _files_ignored,
-                _ent_to_auto,
-                parse_result,
-            ) = await self._parser.async_parse(
+            parse_result = await self._parser.async_parse(
                 self.hass.config.config_dir,
                 ignored_files,
                 custom_domains=custom_domains,

--- a/tests/tests/test_jinja_comments.py
+++ b/tests/tests/test_jinja_comments.py
@@ -31,7 +31,11 @@ sensor:
     test_file.write_text(yaml_content, encoding="utf-8")
     
     # Parse the directory
-    entities, services, _, _, _, _ = asyncio.run(parser_client.async_parse(str(tmp_path), []))
+    asyncio.run(parser_client.async_parse(str(tmp_path), []))
+    
+    # Get results from DB
+    items = parser_client.get_found_items(item_type='all')
+    entities = [item[0] for item in items if item[3] == 'entity']
     
     # Assertions
     assert "sensor.valid_entity" in entities, "Should find valid entity 1"

--- a/tests/tests/test_lovelace_discovery.py
+++ b/tests/tests/test_lovelace_discovery.py
@@ -26,7 +26,11 @@ async def test_lovelace_dynamic_discovery(parser_client, tmp_path):
             shutil.copy(file_path, storage_dir / file_path.name)
     
     # 3. Run Parser on the tmp_path
-    parsed_entities, _, _, _, _, _ = await parser_client.async_parse(str(tmp_path), [])
+    await parser_client.async_parse(str(tmp_path), [])
+    
+    # Get results from DB
+    items = parser_client.get_found_items(item_type='all')
+    parsed_entities = [item[0] for item in items if item[3] == 'entity']
     
     # 4. Assertions for Lovelace Files (Dynamic Discovery)
     assert "sensor.test_main" in parsed_entities, "Should find entity in 'lovelace'"

--- a/tests/tests/test_parser_advanced.py
+++ b/tests/tests/test_parser_advanced.py
@@ -28,7 +28,9 @@ def test_ignored_patterns(parser_client, new_test_data_dir, tmp_path):
     shutil.copy(source_file, dest_file)
 
     # Scan the temp directory which contains ONLY the file we want to test
-    entities, _, _, _, _, _ = asyncio.run(parser_client.async_parse(str(dest_dir), []))
+    asyncio.run(parser_client.async_parse(str(dest_dir), []))
+    items = parser_client.get_found_items(item_type='all')
+    entities = [item[0] for item in items if item[3] == 'entity']
 
     # H:1 Underscore Suffix
     assert "sensor.temp_var_" not in entities
@@ -60,7 +62,10 @@ def test_ignored_keys(parser_client, new_test_data_dir):
     yaml_file = Path(new_test_data_dir) / "yaml_config" / "keys_ignored.yaml"
     yaml_dir = str(yaml_file.parent)
 
-    entities, services, _, _, _, _ = asyncio.run(parser_client.async_parse(yaml_dir, []))
+    asyncio.run(parser_client.async_parse(yaml_dir, []))
+    items = parser_client.get_found_items(item_type='all')
+    entities = [item[0] for item in items if item[3] == 'entity']
+    services = [item[0] for item in items if item[3] == 'service']
 
     assert "light.example_entity" not in entities
     assert "sensor.test" not in entities
@@ -74,7 +79,9 @@ def test_custom_tags(parser_client, new_test_data_dir):
     yaml_file = Path(new_test_data_dir) / "yaml_config" / "custom_tags.yaml"
     yaml_dir = str(yaml_file.parent)
 
-    entities, _, _, _, _, _ = asyncio.run(parser_client.async_parse(yaml_dir, []))
+    asyncio.run(parser_client.async_parse(yaml_dir, []))
+    items = parser_client.get_found_items(item_type='all')
+    entities = [item[0] for item in items if item[3] == 'entity']
 
     # !secret http_password resolves to string "http_password", not an entity.
     # !secret "sensor.secret_sensor" resolves to string "sensor.secret_sensor".
@@ -89,7 +96,10 @@ def test_templates_and_prefixes(parser_client, new_test_data_dir):
     yaml_file = Path(new_test_data_dir) / "yaml_config" / "templates.yaml"
     yaml_dir = str(yaml_file.parent)
 
-    entities, services, _, _, _, _ = asyncio.run(parser_client.async_parse(yaml_dir, []))
+    asyncio.run(parser_client.async_parse(yaml_dir, []))
+    items = parser_client.get_found_items(item_type='all')
+    entities = [item[0] for item in items if item[3] == 'entity']
+    services = [item[0] for item in items if item[3] == 'service']
 
     # H:11 Embedded Services
     assert "light.turn_on" in services

--- a/tests/tests/test_parser_automations_scripts.py
+++ b/tests/tests/test_parser_automations_scripts.py
@@ -23,7 +23,10 @@ def test_automations_parsing(parser_client, new_test_data_dir):
     yaml_file = Path(new_test_data_dir) / "yaml_config" / "automations.yaml"
     yaml_dir = str(yaml_file.parent)
 
-    entities, services, _, _, _, _ = asyncio.run(parser_client.async_parse(yaml_dir, []))
+    asyncio.run(parser_client.async_parse(yaml_dir, []))
+    items = parser_client.get_found_items(item_type='all')
+    entities = [item[0] for item in items if item[3] == 'entity']
+    services = [item[0] for item in items if item[3] == 'service']
 
     # Check Entities
     assert "binary_sensor.motion_sensor" in entities
@@ -49,7 +52,10 @@ def test_scripts_parsing(parser_client, new_test_data_dir):
     yaml_file = Path(new_test_data_dir) / "yaml_config" / "scripts.yaml"
     yaml_dir = str(yaml_file.parent)
 
-    entities, services, _, _, _, _ = asyncio.run(parser_client.async_parse(yaml_dir, []))
+    asyncio.run(parser_client.async_parse(yaml_dir, []))
+    items = parser_client.get_found_items(item_type='all')
+    entities = [item[0] for item in items if item[3] == 'entity']
+    services = [item[0] for item in items if item[3] == 'service']
 
     assert "vacuum.robot_cleaner" in entities
     assert "vacuum.start" in services
@@ -69,7 +75,7 @@ def test_package_mixed_contexts(parser_client, new_test_data_dir):
     yaml_file = Path(new_test_data_dir) / "yaml_config" / "package_example.yaml"
     yaml_dir = str(yaml_file.parent)
 
-    _, _, _, _, _, _ = asyncio.run(parser_client.async_parse(yaml_dir, []))
+    asyncio.run(parser_client.async_parse(yaml_dir, []))
 
     # 1. Automation Context
     context1 = parser_client.get_automation_context('input_boolean.package_trigger')

--- a/tests/tests/test_parser_basic.py
+++ b/tests/tests/test_parser_basic.py
@@ -24,7 +24,10 @@ def test_basic_yaml_parsing(parser_client, new_test_data_dir):
     yaml_dir = str(yaml_file.parent)
 
     # Parse the directory
-    entities, services, _, _, _, _ = asyncio.run(parser_client.async_parse(yaml_dir, []))
+    asyncio.run(parser_client.async_parse(yaml_dir, []))
+    items = parser_client.get_found_items(item_type='all')
+    entities = [item[0] for item in items if item[3] == 'entity']
+    services = [item[0] for item in items if item[3] == 'service']
 
     # Check Entities
     assert "sensor.skylight" in entities, "Should detect entity in template"
@@ -48,9 +51,10 @@ def test_json_files_ignored(parser_client, new_test_data_dir):
 
     # We pass the file path, but the scanner internal filter should reject it based on extension
     # Scan the directory
-    entities, services, files_parsed, _, _, _ = asyncio.run(
-        parser_client.async_parse(json_dir, [])
-    )
+    asyncio.run(parser_client.async_parse(json_dir, []))
+    items = parser_client.get_found_items(item_type='all')
+    entities = [item[0] for item in items if item[3] == 'entity']
+    services = [item[0] for item in items if item[3] == 'service']
 
     # dashboard.json is ignored. .storage/lovelace_dashboards is whitelisted and parsed.
     # But wait, this test expects everything to be ignored?
@@ -86,7 +90,9 @@ def test_extensionless_json_parsing(parser_client, new_test_data_dir):
     )
     root_dir = str(Path(new_test_data_dir) / "json_config")
 
-    entities, _, _, _, _, _ = asyncio.run(parser_client.async_parse(root_dir, []))
+    asyncio.run(parser_client.async_parse(root_dir, []))
+    items = parser_client.get_found_items(item_type='all')
+    entities = [item[0] for item in items if item[3] == 'entity']
 
     assert "sensor.storage_sensor_1" in entities
     assert "sensor.storage_sensor_2" in entities
@@ -98,7 +104,10 @@ def test_invalid_file_extension(parser_client, new_test_data_dir):
     txt_file = Path(new_test_data_dir) / "yaml_config" / "invalid_file.txt"
     yaml_dir = str(txt_file.parent)
 
-    entities, services, _, _, _, _ = asyncio.run(parser_client.async_parse(yaml_dir, []))
+    asyncio.run(parser_client.async_parse(yaml_dir, []))
+    items = parser_client.get_found_items(item_type='all')
+    entities = [item[0] for item in items if item[3] == 'entity']
+    services = [item[0] for item in items if item[3] == 'service']
 
     assert "sensor.invalid_file_test" not in entities
     assert "light.invalid_file_test" not in services

--- a/tests/tests/test_parser_config_entries.py
+++ b/tests/tests/test_parser_config_entries.py
@@ -76,9 +76,10 @@ def test_parse_core_config_entries(parser_client, tmp_path):
     # This implies we might need to add it to whitelist too if it's not there.
     # Let's check the current whitelist in parser_const.py later. For now, we assume if it's not whitelisted, the test will fail as expected (baseline).
     
-    parsed_entities, parsed_services, _, _, _, _ = asyncio.run(
-        parser_client.async_parse(str(tmp_path), [])
-    )
+    asyncio.run(parser_client.async_parse(str(tmp_path), []))
+    items = parser_client.get_found_items(item_type='all')
+    parsed_entities = [item[0] for item in items if item[3] == 'entity']
+    parsed_services = [item[0] for item in items if item[3] == 'service']
     
     # Assertions
     

--- a/tests/tests/test_parser_esphome.py
+++ b/tests/tests/test_parser_esphome.py
@@ -21,7 +21,10 @@ def test_esphome_context(parser_client, new_test_data_dir):
     yaml_file = Path(new_test_data_dir) / "yaml_config" / "esphome" / "device.yaml"
     yaml_dir = str(yaml_file.parent)
 
-    entities, services, _, _, _, _ = asyncio.run(parser_client.async_parse(yaml_dir, []))
+    asyncio.run(parser_client.async_parse(yaml_dir, []))
+    items = parser_client.get_found_items(item_type='all')
+    entities = [item[0] for item in items if item[3] == 'entity']
+    services = [item[0] for item in items if item[3] == 'service']
 
     # Allowed: keys are 'service', 'action', 'entity_id'
     assert "light.turn_on" in services

--- a/tests/tests/test_parser_false_positives_suffix.py
+++ b/tests/tests/test_parser_false_positives_suffix.py
@@ -21,7 +21,9 @@ def test_false_positives_suffix(parser_client, new_test_data_dir):
     yaml_file = Path(new_test_data_dir) / "yaml_config" / "false_positives_suffix.yaml"
     yaml_dir = str(yaml_file.parent)
 
-    entities, services, _, _, _, _ = asyncio.run(parser_client.async_parse(yaml_dir, []))
+    asyncio.run(parser_client.async_parse(yaml_dir, []))
+    items = parser_client.get_found_items(item_type='all')
+    entities = [item[0] for item in items if item[3] == 'entity']
 
     # Valid entities should be present
     assert "sensor.camera_1" in entities

--- a/tests/tests/test_parser_file_size.py
+++ b/tests/tests/test_parser_file_size.py
@@ -28,7 +28,9 @@ def test_large_file_skipped(parser_client, tmp_path, caplog):
     normal_file.write_text("sensor:\n  - platform: template\n    sensors:\n      test: \n        value_template: '{{ states.sensor.valid }}'", encoding="utf-8")
 
     # Parse
-    entities, _, _, _, _, _ = asyncio.run(parser_client.async_parse(str(config_dir), []))
+    asyncio.run(parser_client.async_parse(str(config_dir), []))
+    items = parser_client.get_found_items(item_type='all')
+    entities = [item[0] for item in items if item[3] == 'entity']
 
     # Verify normal file parsed
     assert "sensor.valid" in entities

--- a/tests/tests/test_parser_ha_domains.py
+++ b/tests/tests/test_parser_ha_domains.py
@@ -20,7 +20,9 @@ def test_ha_domains_parsing(parser_client, new_test_data_dir):
     yaml_dir = str(yaml_file.parent)
 
     # Parse the directory
-    entities, _, _, _, _, _ = asyncio.run(parser_client.async_parse(yaml_dir, []))
+    asyncio.run(parser_client.async_parse(yaml_dir, []))
+    items = parser_client.get_found_items(item_type='all')
+    entities = [item[0] for item in items if item[3] == 'entity']
 
     # List of domains to check
     domains_to_check = [

--- a/tests/tests/test_parser_path_exclusion.py
+++ b/tests/tests/test_parser_path_exclusion.py
@@ -25,7 +25,9 @@ def test_path_exclusion(parser_client, new_test_data_dir):
     # But since we put it in yaml_config, it might parse other files too.
     # We should filter results or check just for our specific entities.
 
-    entities, services, _, _, _, _ = asyncio.run(parser_client.async_parse(yaml_dir, []))
+    asyncio.run(parser_client.async_parse(yaml_dir, []))
+    items = parser_client.get_found_items(item_type='all')
+    entities = [item[0] for item in items if item[3] == 'entity']
 
     assert "person.valid_entity" in entities
     assert "person.space_preceded" in entities

--- a/tests/tests/test_parser_regressions.py
+++ b/tests/tests/test_parser_regressions.py
@@ -20,7 +20,9 @@ def test_template_false_positive(parser_client, new_test_data_dir):
     yaml_dir = str(yaml_file.parent)
 
     # Parse just this file (but scanning dir scans all, so rely on specific entity checks)
-    entities, services, _, _, _, _ = asyncio.run(parser_client.async_parse(yaml_dir, []))
+    asyncio.run(parser_client.async_parse(yaml_dir, []))
+    items = parser_client.get_found_items(item_type='all')
+    entities = [item[0] for item in items if item[3] == 'entity']
 
     # Check entity in action target
     # NOTE: todo.cleaning is in 'action' block.
@@ -36,7 +38,9 @@ def test_automation_context_regression(parser_client, new_test_data_dir):
     yaml_file = Path(new_test_data_dir) / "yaml_config" / "automation_context_regression.yaml"
     yaml_dir = str(yaml_file.parent)
 
-    entities, services, _, _, _, _ = asyncio.run(parser_client.async_parse(yaml_dir, []))
+    asyncio.run(parser_client.async_parse(yaml_dir, []))
+    items = parser_client.get_found_items(item_type='all')
+    entities = [item[0] for item in items if item[3] == 'entity']
 
     entity_id = "input_boolean.mode_cleaning_house"
     assert entity_id in entities
@@ -52,7 +56,9 @@ def test_root_automation(parser_client, new_test_data_dir):
     yaml_file = Path(new_test_data_dir) / "yaml_config" / "root_automation.yaml"
     yaml_dir = str(yaml_file.parent)
 
-    entities, services, _, _, _, _ = asyncio.run(parser_client.async_parse(yaml_dir, []))
+    asyncio.run(parser_client.async_parse(yaml_dir, []))
+    items = parser_client.get_found_items(item_type='all')
+    entities = [item[0] for item in items if item[3] == 'entity']
 
     entity_id = "sensor.root_trigger"
     assert entity_id in entities

--- a/tests/tests/test_service_template.py
+++ b/tests/tests/test_service_template.py
@@ -19,7 +19,10 @@ def test_service_template(parser_client, new_test_data_dir):
     yaml_file = Path(new_test_data_dir) / "yaml_config" / "service_template.yaml"
     yaml_dir = str(yaml_file.parent)
 
-    entities, services, _, _, _, _ = asyncio.run(parser_client.async_parse(yaml_dir, []))
+    asyncio.run(parser_client.async_parse(yaml_dir, []))
+    items = parser_client.get_found_items(item_type='all')
+    entities = [item[0] for item in items if item[3] == 'entity']
+    services = [item[0] for item in items if item[3] == 'service']
 
     # light.living_room is entity
     assert "light.living_room" in entities

--- a/uv.lock
+++ b/uv.lock
@@ -798,21 +798,21 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.49"
+version = "1.42.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/20/91/105aa17e0f3a566d33e2d8a3b32a70f553b1ad500d9756c6dd63991d8354/boto3-1.42.49.tar.gz", hash = "sha256:9cd252f640567b86e92b0a8ffdd4ade9a3018ee357c724bff6a21b8c8a41be0c", size = 112877, upload-time = "2026-02-13T20:29:57.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/41/7a7280875ec000e280b0392478a5d6247bc88e7ecf2ae6ec8f4ddb35b014/boto3-1.42.50.tar.gz", hash = "sha256:38545d7e6e855fefc8a11e899ccbd6d2c9f64671d6648c2acfb1c78c1057a480", size = 112851, upload-time = "2026-02-16T20:42:09.203Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b1/1fa30cd7b26617d59efbe3a4f3660a5b8b397a4623bf1e67016c4cb6dd0e/boto3-1.42.49-py3-none-any.whl", hash = "sha256:99e1df4361c3f6ff6ade65803c043ea96314826134962dd3b385433b309eb819", size = 140606, upload-time = "2026-02-13T20:29:55.366Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/14/bf4077d843d737bec6f4176e113182a4435a1864e2a819ca07004da8a9ac/boto3-1.42.50-py3-none-any.whl", hash = "sha256:2fdf8f5349b130d62576068a6c47b3eec368a70bc28f16d8cce17c5f7e74fc2e", size = 140604, upload-time = "2026-02-16T20:42:06.652Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.49"
+version = "1.42.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
@@ -820,9 +820,9 @@ dependencies = [
     { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13.2'" },
     { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13.2'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/95/c3a3765ab65073695161e7180d631428cb6e67c18d97e8897871dfe51fcc/botocore-1.42.49.tar.gz", hash = "sha256:333115a64a507697b0c450ade7e2d82bc8b4e21c0051542514532b455712bdcc", size = 14958380, upload-time = "2026-02-13T20:29:47.218Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/fd/e63789133b2bf044c8550cd6766ec93628b0ac18a03f2aa0b80171f0697a/botocore-1.42.50.tar.gz", hash = "sha256:de1e128e4898f4e66877bfabbbb03c61f99366f27520442539339e8a74afe3a5", size = 14958074, upload-time = "2026-02-16T20:41:58.814Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/cd/7e7ceeff26889d1fd923f069381e3b2b85ff6d46c6fd1409ed8f486cc06f/botocore-1.42.49-py3-none-any.whl", hash = "sha256:1c33544f72101eed4ccf903ebb667a803e14e25b2af4e0836e4b871da1c0af37", size = 14630510, upload-time = "2026-02-13T20:29:43.086Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b8/b02ad16c5198e652eafdd8bad76aa62ac094afabbe1241b4be1cd4075666/botocore-1.42.50-py3-none-any.whl", hash = "sha256:3ec7004009d1557a881b1d076d54b5768230849fa9ccdebfd409f0571490e691", size = 14631256, upload-time = "2026-02-16T20:41:55.004Z" },
 ]
 
 [[package]]
@@ -4236,16 +4236,16 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.36.1"
+version = "20.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/ef/d9d4ce633df789bf3430bd81fb0d8b9d9465dfc1d1f0deb3fb62cd80f5c2/virtualenv-20.37.0.tar.gz", hash = "sha256:6f7e2064ed470aa7418874e70b6369d53b66bcd9e9fd5389763e96b6c94ccb7c", size = 5864710, upload-time = "2026-02-16T16:17:59.42Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/2a/dc2228b2888f51192c7dc766106cd475f1b768c10caaf9727659726f7391/virtualenv-20.36.1-py3-none-any.whl", hash = "sha256:575a8d6b124ef88f6f51d56d656132389f961062a9177016a50e4f507bbcc19f", size = 6008258, upload-time = "2026-01-09T18:20:59.425Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4b/6cf85b485be7ec29db837ec2a1d8cd68bc1147b1abf23d8636c5bd65b3cc/virtualenv-20.37.0-py3-none-any.whl", hash = "sha256:5d3951c32d57232ae3569d4de4cc256c439e045135ebf43518131175d9be435d", size = 5837480, upload-time = "2026-02-16T16:17:57.341Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Refactor to remove technical debt left over from an older version of the Watchman integration.
2. Adaptation of parser CLI for new  `ignore_mtime` parameter introduced in #291 


## Motivation and Context

Currently, at the end of WatchmanParser.async_parse (in `parser_core.py`), the engine executes several heavy SQLite queries (`SELECT DISTINCT...`) to build lists of entities, services, and counts. It then returns a massive 6-tuple.
However, its caller in `hub.py` (`WatchmanHub.async_parse`) unpacks this tuple, immediately discards the first 5 elements, and only keeps the `ParseResult` object. This causes a significant and completely unnecessary CPU and I/O overhead.

## How has this been tested?

Existing tests updated to adapt for changed signature of `async_parse` method.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
