### PR TITLE
fix: extend list of STATELESS_DOMAINS (special case for entities with permanent `unknown` state)

### DIFF
--- a/custom_components/watchman/const.py
+++ b/custom_components/watchman/const.py
@@ -31,6 +31,16 @@ PARSE_COOLDOWN = 60
 # delay before start parsing
 DEFAULT_DELAY = 10
 
+STATELESS_DOMAINS = (
+    "button",
+    "input_button",
+    "scene",
+    "event",
+    "notify",
+    "stt",
+    "wake_word",
+)
+
 PACKAGE_NAME = f"custom_components.{DOMAIN}"
 REPORT_SERVICE_NAME = "report"
 LABELS_SERVICE_NAME = "set_ignored_labels"

--- a/custom_components/watchman/utils/utils.py
+++ b/custom_components/watchman/utils/utils.py
@@ -29,6 +29,7 @@ from ..const import (
     CONF_STARTUP_DELAY,
     DEFAULT_OPTIONS,
     DOMAIN_DATA,
+    STATELESS_DOMAINS,
 )
 from .logger import _LOGGER, INDENT
 
@@ -207,7 +208,7 @@ def get_entity_state(
     else:
         state = str(entity_state.state).replace("unavailable", "unavail")
         if (
-            split_entity_id(entry)[0] in ["input_button", "button", "scene"]
+            split_entity_id(entry)[0] in STATELESS_DOMAINS
             and state == "unknown"
         ):
             state = "available"

--- a/tests/tests/test_utils_entity_state.py
+++ b/tests/tests/test_utils_entity_state.py
@@ -1,9 +1,8 @@
 """Test the get_entity_state function in utils."""
-from unittest.mock import MagicMock
-
 import pytest
 from homeassistant.core import HomeAssistant
 
+from custom_components.watchman.const import STATELESS_DOMAINS
 from custom_components.watchman.utils.utils import get_entity_state
 
 
@@ -16,36 +15,24 @@ async def test_get_entity_state_missing(hass: HomeAssistant) -> None:
     assert state == "missing"
 
 
-async def test_get_entity_state_scene_unknown(hass: HomeAssistant) -> None:
-    """Test Scenario B: Entity scene.test_scene exists with state unknown."""
-    hass.states.async_set("scene.test_scene", "unknown")
+@pytest.mark.parametrize("domain", STATELESS_DOMAINS)
+async def test_get_entity_state_stateless_unknown(hass: HomeAssistant, domain: str) -> None:
+    """Test that stateless domains return 'available' when state is 'unknown'."""
+    entity_id = f"{domain}.test_entity"
+    hass.states.async_set(entity_id, "unknown")
     
-    state, _ = get_entity_state(hass, "scene.test_scene")
-    assert state == "available"
+    state, _ = get_entity_state(hass, entity_id)
+    assert state == "available", f"Domain {domain} should be available when unknown"
 
 
-async def test_get_entity_state_button_unknown(hass: HomeAssistant) -> None:
-    """Test Scenario C: Entity button.test_button exists with state unknown."""
-    hass.states.async_set("button.test_button", "unknown")
+@pytest.mark.parametrize("domain", STATELESS_DOMAINS)
+async def test_get_entity_state_stateless_unavailable(hass: HomeAssistant, domain: str) -> None:
+    """Test that stateless domains return 'unavail' when state is 'unavailable'."""
+    entity_id = f"{domain}.test_entity"
+    hass.states.async_set(entity_id, "unavailable")
     
-    state, _ = get_entity_state(hass, "button.test_button")
-    assert state == "available"
-
-
-async def test_get_entity_state_input_button_unknown(hass: HomeAssistant) -> None:
-    """Test Scenario C (extra): Entity input_button.test_button exists with state unknown."""
-    hass.states.async_set("input_button.test_button", "unknown")
-    
-    state, _ = get_entity_state(hass, "input_button.test_button")
-    assert state == "available"
-
-
-async def test_get_entity_state_scene_unavailable(hass: HomeAssistant) -> None:
-    """Test Scenario D: Entity scene.test_scene exists with state unavailable."""
-    hass.states.async_set("scene.test_scene", "unavailable")
-    
-    state, _ = get_entity_state(hass, "scene.test_scene")
-    assert state == "unavail"
+    state, _ = get_entity_state(hass, entity_id)
+    assert state == "unavail", f"Domain {domain} should be unavail when unavailable"
 
 
 async def test_get_entity_state_valid_timestamp(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Refactored the handling of stateless entities in Watchman by introducing a new `STATELESS_DOMAINS` constant and expanding the list of supported domains.

**Key changes:**

* Introduced `STATELESS_DOMAINS` constant in `const.py` containing: `button`, `input_button`, `scene`, `event`, `notify`, `stt`, and `wake_word`.
* Refactored `get_entity_state` in `utils.py` to use the new constant instead of a hardcoded list, removing code smell.
* Refactored the corresponding pytest suite to use `@pytest.mark.parametrize`, ensuring all stateless domains are dynamically tested for correctly mapping the `unknown` state to `available`.

## Motivation and Context

In Home Assistant, several entity domains are entirely stateless. Instead of a traditional `on`/`off` state, their state in the State Machine represents the timestamp of their last activation or trigger. Upon a Home Assistant restart, and prior to their first activation in the current session, their default state is inherently `unknown`.

Previously, this exception was hardcoded in `utils.py` and only covered `button`, `input_button`, and `scene`. This caused Watchman to generate false positive "missing/unknown" reports for other stateless integrations.

By mapping the `unknown` state to `available` for the complete list of stateless domains (`event`, `notify`, `stt`, `wake_word`, etc.), we eliminate visual noise in the Watchman report. Moving these domains to a dedicated constant also improves code maintainability and follows better architectural practices, making it easier to add new stateless domains in future Home Assistant releases.

## How has this been tested?
Test `tests/tests/test_utils_entity_state.py` updated, verified that for all these domains, an `unknown` state correctly returns `available`, while an `unavailable` state returns `unavail`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.

