### PR TITLE
fix: remove report deprecated params from bl

### DIFF
--- a/custom_components/watchman/services.py
+++ b/custom_components/watchman/services.py
@@ -108,7 +108,7 @@ class WatchmanServicesSetup:
                 },
             )
 
-        force_parsing = call.data.get(CONF_FORCE_PARSING, call.data.get(CONF_PARSE_CONFIG, False))
+        force_parsing = call.data.get(CONF_FORCE_PARSING, False)
 
         # Always trigger a parser run (default: incremental, unless forced)
         await self.coordinator.async_force_parse(ignore_mtime=force_parsing)

--- a/custom_components/watchman/utils/report.py
+++ b/custom_components/watchman/utils/report.py
@@ -53,19 +53,14 @@ async def report(
     chunk_size: int | None = None,
 ) -> list[str]:
     """Generate a report of missing entities and services."""
-    from ..const import CONF_EXCLUDE_DISABLED_AUTOMATION
     from ..coordinator import renew_missing_items_list
-
     start_time = time.time()
     entry = get_entry(hass)
     coordinator = entry.runtime_data.coordinator
 
-    # OPTIMIZATION: One-Pass Data Retrieval
     all_items = await coordinator.hub.async_get_all_items()
     service_list = all_items["services"]
     entity_list = all_items["entities"]
-
-    # Build filter context once
     ctx = coordinator._build_filter_context()
 
     missing_services = renew_missing_items_list(

--- a/tests/tests/test_service_force_parsing.py
+++ b/tests/tests/test_service_force_parsing.py
@@ -56,7 +56,7 @@ async def test_report_service_legacy_parse_config(hass: HomeAssistant, mock_coor
             blocking=True,
         )
 
-        mock_coordinator.async_force_parse.assert_called_once_with(ignore_mtime=True)
+        mock_coordinator.async_force_parse.assert_called_once_with(ignore_mtime=False)
 
         # Verify issue created
         mock_create_issue.assert_called_once()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Service Logic Update (`custom_components/watchman/services.py`):
 * Ensured that the force_parsing variable now exclusively relies on the `CONF_FORCE_PARSING` parameter.
 * The deprecated `parse_config` parameter is now a "no-op" regarding parser behavior, meaning it will no longer trigger a full, heavy cache-bypass (`ignore_mtime=True`). It continues to correctly trigger the repair issue warning.

## Motivation and Context

Finalize the deprecation of the `parse_config` action parameter initiated in #291. Fixed a bug that triggered a full rescan of all files (`ignore_mtime: true`) when a user called the report action with `parse_config: true`.

## How has this been tested?

Existing test `test_service_force_parsing.py` updated, all tests passed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
