### PR TITLE
fix: extend uid migration to button entity to prevent _2 suffix

### DIFF
--- a/custom_components/watchman/utils/entity.py
+++ b/custom_components/watchman/utils/entity.py
@@ -1,0 +1,25 @@
+"""Entity utilities for Watchman."""
+from homeassistant.helpers import entity_registry as er
+from .logger import _LOGGER
+
+async def update_or_cleanup_entity(
+    ent_reg: er.EntityRegistry, platform: str, domain: str, old_uid: str, new_uid: str
+) -> None:
+    """Migrate entity unique ID or remove duplicates."""
+    if old_entity_id := ent_reg.async_get_entity_id(platform, domain, old_uid):
+        # we found entities with old-style uid in registry, apply migration logic
+        if ent_reg.async_get_entity_id(platform, domain, new_uid):
+            ent_reg.async_remove(old_entity_id)
+            _LOGGER.debug(
+                "async_setup_entry: 2 entities found in registry. "
+                "Will remove %s in favor of %s.",
+                old_uid,
+                new_uid,
+            )
+        else:
+            _LOGGER.debug(
+                "async_setup_entry: Entity with old uid %s was migrated to %s.",
+                old_uid,
+                new_uid,
+            )
+            ent_reg.async_update_entity(old_entity_id, new_unique_id=new_uid)

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,7 +11,7 @@ To ensure snapshot consistency with Linux CI, run tests using the Docker wrapper
 ./scripts/test_local --version 2026.2.0
 
 # Run specific test file
-./scripts/test_local tests/tests/test_init.py
+./scripts/test_local tests/test_init.py
 
 # Update snapshots
 ./scripts/test_local --snapshot-update
@@ -40,4 +40,4 @@ Command | Description
 ------- | -----------
 `./scripts/test_local` | **Standard way to run tests**
 `./scripts/test_local --durations=10` | Show slowest 10 tests
-`./scripts/test_local tests/tests/test_init.py` | Run specific test file
+`./scripts/test_local tests/test_init.py` | Run specific test file

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,64 +1,115 @@
-"""Test Watchman button entity."""
-from unittest.mock import patch
-
-from custom_components.watchman.const import DOMAIN, REPORT_SERVICE_NAME
-from tests import async_init_integration
-
+"""Test Watchman button entity migration."""
+from copy import deepcopy
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.watchman.const import (
+    CONFIG_ENTRY_MINOR_VERSION,
+    DEFAULT_OPTIONS,
+    DOMAIN,
+)
+from tests import async_init_integration
 
 
-async def test_button_press_triggers_report(hass: HomeAssistant):
-    """Test that pressing the button triggers the report service."""
-    await async_setup_component(hass, "persistent_notification", {})
+async def test_button_legacy_uid_migration(hass: HomeAssistant):
+    """Scenario A: Legacy uid migration ({entry_id}_watchman_report_button)."""
+    entity_registry = er.async_get(hass)
+    entry_id = "test_entry_id_123"
+    button_key = "report_button"
+    old_uid = f"{entry_id}_{DOMAIN}_{button_key}"
+    new_uid = f"{DOMAIN}_{button_key}"
+
+    # Pre-populate registry with old UID
+    entity_registry.async_get_or_create(
+        "button", DOMAIN, old_uid, suggested_object_id="watchman_create_report_file"
+    )
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id=entry_id,
+        title="Watchman",
+        unique_id="watchman_unique_id",
+        version=2,
+        minor_version=CONFIG_ENTRY_MINOR_VERSION,
+        data=deepcopy(DEFAULT_OPTIONS),
+    )
+
+    await async_init_integration(hass, config_entry=config_entry)
+
+    try:
+        # 1. Verify new UID exists
+        entry = entity_registry.async_get("button.watchman_create_report_file")
+        assert entry
+        assert entry.unique_id == new_uid
+
+        # 2. Verify old UID is GONE
+        assert entity_registry.async_get_entity_id("button", DOMAIN, old_uid) is None
+
+        # 3. Verify only one button exists for this platform
+        all_watchman_buttons = [
+            e
+            for e in entity_registry.entities.values()
+            if e.domain == "button" and e.platform == DOMAIN
+        ]
+        assert len(all_watchman_buttons) == 1
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+
+async def test_button_duplicate_domain_uid_migration(hass: HomeAssistant):
+    """Scenario B: Duplicate-domain uid migration (watchman_watchman_report_button)."""
+    entity_registry = er.async_get(hass)
+    button_key = "report_button"
+    old_uid = f"{DOMAIN}_{DOMAIN}_{button_key}"
+    new_uid = f"{DOMAIN}_{button_key}"
+
+    # Pre-populate registry with duplicate-domain UID
+    entity_registry.async_get_or_create(
+        "button", DOMAIN, old_uid, suggested_object_id="watchman_create_report_file"
+    )
+
     config_entry = await async_init_integration(hass)
 
     try:
-        # Verify button entity exists
+        # 1. Verify new UID exists
+        entry = entity_registry.async_get("button.watchman_create_report_file")
+        assert entry
+        assert entry.unique_id == new_uid
+
+        # 2. Verify old UID is GONE
+        assert entity_registry.async_get_entity_id("button", DOMAIN, old_uid) is None
+
+        # 3. Verify only one button exists
+        all_watchman_buttons = [
+            e
+            for e in entity_registry.entities.values()
+            if e.domain == "button" and e.platform == DOMAIN
+        ]
+        assert len(all_watchman_buttons) == 1
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+
+async def test_button_clean_install(hass: HomeAssistant):
+    """Scenario C: Clean install (no migration needed)."""
+    config_entry = await async_init_integration(hass)
+
+    try:
         entity_registry = er.async_get(hass)
         entry = entity_registry.async_get("button.watchman_create_report_file")
         assert entry
-        assert entry.platform == DOMAIN
+        assert entry.unique_id == "watchman_report_button"
+        assert entry.entity_id == "button.watchman_create_report_file"
 
-        # Patch the service call to verify it's called
-        # Also patch async_report_to_file to prevent actual file writing failure (due to empty path in defaults)
-        # And patch button.get_config so notification gets a path
-        with patch(
-            "homeassistant.core.ServiceRegistry.async_call",
-            wraps=hass.services.async_call
-        ) as mock_service_call, \
-             patch("custom_components.watchman.services.async_report_to_file") as mock_write_file, \
-             patch("custom_components.watchman.button.get_config", return_value="/tmp/report.txt"):
-
-            # Press the button
-            await hass.services.async_call(
-                "button", "press", {"entity_id": "button.watchman_create_report_file"}, blocking=True
-            )
-            await hass.async_block_till_done()
-
-            # Verify watchman.report was called with correct parameters
-            # mock_service_call captures all service calls.
-
-            found_call = False
-            found_notify = False
-
-            for call in mock_service_call.mock_calls:
-                domain = call.args[0] if call.args else call.kwargs.get('domain')
-                service = call.args[1] if len(call.args) > 1 else call.kwargs.get('service')
-
-                if domain == DOMAIN and service == REPORT_SERVICE_NAME:
-                    service_data = call.args[2] if len(call.args) > 2 else call.kwargs.get('service_data')
-                    if service_data == {"parse_config": True}:
-                        found_call = True
-
-                if domain == "persistent_notification" and service == "create":
-                    service_data = call.args[2] if len(call.args) > 2 else call.kwargs.get('service_data')
-                    if service_data and service_data.get("title") == "🛡️Watchman":
-                        found_notify = True
-
-            assert found_call, "watchman.report service was not called with parse_config=True"
-            assert found_notify, "persistent_notification.create was not called with title='🛡️Watchman'"
+        all_watchman_buttons = [
+            e
+            for e in entity_registry.entities.values()
+            if e.domain == "button" and e.platform == DOMAIN
+        ]
+        assert len(all_watchman_buttons) == 1
     finally:
         await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()


### PR DESCRIPTION
## Description

Extracts `update_or_cleanup_entity()` from `sensor.py` into a new shared utility module `custom_components/watchman/utils/entity.py` and applies the same legacy unique-ID migration logic to `button.py`.

The shared helper now accepts a `platform` argument so it works correctly for both `sensor` and `button` platforms.

## Motivation and Context

The button entity `button.watchman_create_report_file` was sometimes registered with a `_2` suffix on installations upgrading from pre-0.8.x versions.

**Root cause:** `sensor.py` has long contained migration logic that renames stale registry entries created by older uid formats (`{entry_id}_watchman_{key}` and `watchman_watchman_{key}`) to the current format (`watchman_{key}`). The equivalent migration was never added to `button.py`, so users with a legacy registry entry for the button ended up with two conflicting entries, and Home Assistant resolved the conflict by appending `_2` to the new entity's ID.

## How has this been tested?

Three new tests were added to `tests/test_button.py`, replacing the previous smoke test:

- **Scenario A — Legacy uid migration** (`{entry_id}_watchman_report_button`): pre-populates the entity registry with the old format, loads the integration, and asserts that only one button entity exists with the correct uid and entity_id (no `_2` suffix).
- **Scenario B — Duplicate-domain uid migration** (`watchman_watchman_report_button`): same flow for the second legacy format introduced during early 0.8 development.
- **Scenario C — Clean install**: verifies correct registration when no stale entries are present.

All existing tests continue to pass.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.