### PR TITLE
fix: move report button under Controls pane in Service Info

### DIFF
--- a/custom_components/watchman/button.py
+++ b/custom_components/watchman/button.py
@@ -4,7 +4,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
-from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import CONF_REPORT_PATH, DOMAIN, REPORT_SERVICE_NAME
@@ -17,7 +16,6 @@ class WatchmanReportButton(ButtonEntity):
 
     _attr_has_entity_name = True
     _attr_translation_key = "create_report_file"
-    _attr_entity_category = EntityCategory.CONFIG
     _attr_icon = "mdi:file-document-outline"
 
     def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Move "Create Report File" button from Configuration section of Service Info screen to Controls section.

## Motivation and Context

Since **Create Report File** is a functional action, the corresponding button has been moved from the **Configuration** pane to **Controls** pane.

## How has this been tested?

Existing tests passed.

## Screenshots:

<img width="333" height="192" alt="image" src="https://github.com/user-attachments/assets/b815b8b5-81ef-45cd-a325-24b78a157355" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.

