### PR TITLE
fix: correctly cancel delay timer

### DIFF
--- a/custom_components/watchman/coordinator.py
+++ b/custom_components/watchman/coordinator.py
@@ -690,9 +690,9 @@ class WatchmanCoordinator(DataUpdateCoordinator):
             self._cooldown_unsub = None
 
         # Cancel pending delay
-            if self._delay_unsub:
-                self._delay_unsub.cancel()
-                self._delay_unsub = None
+        if self._delay_unsub:
+            self._delay_unsub.cancel()
+            self._delay_unsub = None
 
         # If already running, return the running task
         if self._parse_task and not self._parse_task.done():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes a bug in async_force_parse where the delay timer was not cancelled if the cooldown timer was inactive. This could lead to duplicate parses being triggered when a forced parse was requested while a delayed parse was pending.

## Motivation and Context
  When `async_force_parse` is called (e.g. via the report service with `parse_config=True`), it should cancel any pending scheduled parses (both cooldown and delay). Previously, the cancellation of the delay timer was incorrectly nested inside the cooldown check block. This meant that if a delay was active but no cooldown was active, the delay timer would remain active and eventually fire, causing an unnecessary second parse.
  
## How has this been tested?
   - Added a new regression test `test_force_parse_cancels_pending_delay` 
   - Ran the full test suite to ensure no regressions.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
