### PR TITLE
fix: exclude unavailable entities when ignored

### DIFF
--- a/custom_components/watchman/coordinator.py
+++ b/custom_components/watchman/coordinator.py
@@ -345,20 +345,11 @@ class WatchmanCoordinator(DataUpdateCoordinator):
             _LOGGER.debug(f"Found {num_off_auto} automations in 'off' state and {num_disabled_auto} registry-disabled automations.")
             _LOGGER.debug("They will be excluded from report due to user settings.")
 
-        # Normalize ignored states (e.g. unavail -> unavailable if needed, or handle in loop)
-        # For now, we pass raw config list and handle mapping in the loop for backward compatibility
-        ignored_states_mapped = set()
-        for s in ignored_states:
-             if s == "unavailable":
-                 ignored_states_mapped.add("unavail")
-             else:
-                 ignored_states_mapped.add(s)
-
         self._filter_context_cache = FilterContext(
             entity_registry=ent_reg,
             disabled_automations=disabled_automations,
             automation_map=automation_map,
-            ignored_states=ignored_states_mapped,
+            ignored_states=set(ignored_states),
             ignored_labels=ignored_labels,
             exclude_disabled=exclude_disabled,
         )

--- a/tests/test_report_generation.py
+++ b/tests/test_report_generation.py
@@ -91,3 +91,60 @@ async def test_report_generation_snapshot(hass, new_test_data_dir, tmp_path, sna
     finally:
         await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
+
+
+@patch("custom_components.watchman.utils.report.parsing_stats", new=mock_stats)
+@pytest.mark.asyncio
+async def test_report_excludes_unavailable_when_ignored(hass, new_test_data_dir, tmp_path):
+    """Test that ignored unavailable state excludes entities from the report."""
+    config_dir = str(Path(new_test_data_dir) / "reports" / "test_report_generation")
+
+    hass.config.config_dir = config_dir
+
+    def mock_path_side_effect(*args):
+        return str(tmp_path.joinpath(*args))
+
+    hass.config.path = MagicMock(side_effect=mock_path_side_effect)
+
+    report_file = tmp_path / "watchman_report.txt"
+
+    config_entry = await async_init_integration(
+        hass,
+        add_params={
+            CONF_INCLUDED_FOLDERS: config_dir,
+            CONF_SECTION_APPEARANCE_LOCATION: {
+                CONF_REPORT_PATH: str(report_file),
+            },
+            CONF_IGNORED_STATES: ["unavailable"],
+        },
+    )
+
+    try:
+        hass.states.async_set("sensor.outside_temp", "25.0")
+        hass.states.async_set("light.living_room", "on")
+        hass.states.async_set("binary_sensor.motion_sensor", "unavailable")
+        hass.states.async_set("input_boolean.unknown_boolean", "unknown")
+
+        for domain in ["light", "switch", "alarm_control_panel", "vacuum", "script", "notify", "automation"]:
+            hass.services.async_register(domain, "turn_on", lambda x: None)
+            hass.services.async_register(domain, "turn_off", lambda x: None)
+            hass.services.async_register(domain, "toggle", lambda x: None)
+
+        hass.services.async_register("alarm_control_panel", "arm_home", lambda x: None)
+        hass.services.async_register("vacuum", "start", lambda x: None)
+        hass.services.async_register("notify", "telegram", lambda x: None)
+        hass.services.async_register("notify", "persistent_notification", lambda x: None)
+        hass.services.async_register("notify", "mobile_app_phone", lambda x: None)
+
+        await hass.services.async_call(DOMAIN, "report")
+        await hass.async_block_till_done()
+
+        assert report_file.exists()
+
+        content = report_file.read_text(encoding="utf-8")
+
+        assert "binary_sensor.motion_sensor" not in content
+        assert "input_boolean.unknown_boolean" in content
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()


### PR DESCRIPTION
## Description

  This PR fixes a regression where entities with state `unavailable` were still included in reports even
  when `ignored_states` contained `unavailable`.

  The issue was caused by a stale legacy conversion in the filtering path:
  - config/options use the canonical value `unavailable`
  - filter context still converted it to `unavail`
  - entity state resolution now returns `unavailable`

  That mismatch caused the ignore check to fail.

  The fix removes the legacy conversion from filtering logic and keeps `unavail` only for report/UI
  formatting.

  A new end-to-end regression test was added for this exact case.

  ## Motivation and Context

  Users reported that selecting `unavailable` in ignored states did not exclude unavailable entities from
  the report.  The regression appears to have been introduced during the state handling cleanup in PR #300.

## How has this been tested?
`test_report_excludes_unavailable_when_ignored.py` has been added.
Existing tests passed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist


- [x] My code follows the code style of this project.
