### PR TITLE
Add configurable file size limit to Watchman integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Option | Description | Example
 ⚙️ Exclude entities used by disabled automations | If enabled, entities referenced only by disabled automations will be excluded from the report. | UI flag
 ⚙️ Obfuscate sensitive data in logs | By default, potentially sensitive data, such as entity IDs, are masked in debug logs. This option enables the display of full entity names and actions in log files. | UI flag 
 ⚙️ Enforce max file size limit | Switch off max file size limit for parser if you have warning messages about large files in log.  | UI flag
+⚙️ Maximum file size (KB) | Maximum size of a configuration file that watchman will parse. Files exceeding this limit are skipped when "Enforce max file size limit" is enabled. Accepts values between 100 and 10000 KB. | `500`
 ⚙️ Report location | Report location and filename. | `/config/watchman_report.txt`
 ⚙️ Custom header for the report | Custom header for watchman report. | `-== Watchman Report ==-`
 ⚙️ Report's column width | Report's columns width. The list of column widths for the table version of the report. | `30, 7, 60`

--- a/custom_components/watchman/__init__.py
+++ b/custom_components/watchman/__init__.py
@@ -20,6 +20,7 @@ from .const import (
     CONF_IGNORED_ITEMS,
     CONF_IGNORED_STATES,
     CONF_LOG_OBFUSCATE,
+    CONF_MAX_FILE_SIZE,
     CONF_REPORT_PATH,
     CONF_SECTION_APPEARANCE_LOCATION,
     CONF_STARTUP_DELAY,
@@ -329,6 +330,11 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                 if isinstance(val, str):
                     data[key] = [x.strip() for x in val.split(",") if x.strip()]
             current_minor = 6
+
+        if current_minor < 7:
+            _LOGGER.info("Migrating Watchman entry to minor version 7")
+            data[CONF_MAX_FILE_SIZE] = DEFAULT_OPTIONS.get(CONF_MAX_FILE_SIZE, 500)
+            current_minor = 7
 
         if current_minor != config_entry.minor_version:
             hass.config_entries.async_update_entry(

--- a/custom_components/watchman/config_flow.py
+++ b/custom_components/watchman/config_flow.py
@@ -26,6 +26,7 @@ from .const import (
     CONF_IGNORED_LABELS,
     CONF_IGNORED_STATES,
     CONF_LOG_OBFUSCATE,
+    CONF_MAX_FILE_SIZE,
     CONF_REPORT_PATH,
     CONF_SECTION_APPEARANCE_LOCATION,
     CONF_STARTUP_DELAY,
@@ -83,6 +84,9 @@ def _get_data_schema() -> vol.Schema:
             vol.Optional(
                 CONF_ENFORCE_FILE_SIZE,
             ): cv.boolean,
+            vol.Optional(
+                CONF_MAX_FILE_SIZE,
+            ): vol.All(cv.positive_int, vol.Range(min=100, max=10000)),
             vol.Required(CONF_SECTION_APPEARANCE_LOCATION): data_entry_flow.section(
                 vol.Schema(
                     {

--- a/custom_components/watchman/const.py
+++ b/custom_components/watchman/const.py
@@ -14,7 +14,7 @@ DOMAIN_DATA = f"{DOMAIN}_data"
 
 
 CONFIG_ENTRY_VERSION = 2
-CONFIG_ENTRY_MINOR_VERSION = 6
+CONFIG_ENTRY_MINOR_VERSION = 7
 
 DEFAULT_REPORT_FILENAME = f"{DOMAIN}_report.txt"
 DB_FILENAME = f"{DOMAIN}_v2.db"
@@ -84,6 +84,7 @@ CONF_FRIENDLY_NAMES = "friendly_names"
 CONF_LOG_OBFUSCATE = "log_obfuscate"
 CONF_IGNORED_LABELS = "ignored_labels"
 CONF_ENFORCE_FILE_SIZE = "enforce_file_size"
+CONF_MAX_FILE_SIZE = "max_file_size"
 # configuration parameters allowed in watchman.report service data
 CONF_ALLOWED_SERVICE_PARAMS = [
     CONF_SERVICE_NAME,
@@ -164,6 +165,7 @@ DEFAULT_OPTIONS = {
     CONF_STARTUP_DELAY: 30,
     CONF_LOG_OBFUSCATE: True,
     CONF_ENFORCE_FILE_SIZE: True,
+    CONF_MAX_FILE_SIZE: 500,
     CONF_SECTION_APPEARANCE_LOCATION: {
         CONF_HEADER: "-== Watchman Report ==-",
         CONF_REPORT_PATH: "",

--- a/custom_components/watchman/hub.py
+++ b/custom_components/watchman/hub.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from .const import BUNDLED_IGNORED_ITEMS, CONF_ENFORCE_FILE_SIZE, CONF_IGNORED_ITEMS
+from .const import BUNDLED_IGNORED_ITEMS, CONF_ENFORCE_FILE_SIZE, CONF_IGNORED_ITEMS, CONF_MAX_FILE_SIZE
 from .utils.logger import _LOGGER
 from .utils.parser_core import ParseResult, WatchmanParser, get_domains
 from .utils.utils import get_config
@@ -123,6 +123,7 @@ class WatchmanHub:
         try:
             custom_domains = get_domains(self.hass)
             enforce_file_size = get_config(self.hass, CONF_ENFORCE_FILE_SIZE, True)
+            max_file_size = get_config(self.hass, CONF_MAX_FILE_SIZE, 500) * 1024  # Convert KB to bytes
 
             parse_result = await self._parser.async_parse(
                 self.hass.config.config_dir,
@@ -130,6 +131,7 @@ class WatchmanHub:
                 custom_domains=custom_domains,
                 base_path=self.hass.config.config_dir,
                 enforce_file_size=enforce_file_size,
+                max_file_size=max_file_size,
                 ignore_mtime=ignore_mtime,
             )
 

--- a/custom_components/watchman/translations/en.json
+++ b/custom_components/watchman/translations/en.json
@@ -26,7 +26,8 @@
                     "check_lovelace": "Parse UI controlled dashboards",
                     "startup_delay": "Startup delay for watchman sensors initialization",
                     "log_obfuscate": "Obfuscate sensitive data in logs",
-                    "enforce_file_size": "Enforce max file size limit"
+                    "enforce_file_size": "Enforce max file size limit",
+                    "max_file_size": "Maximum file size (KB)"
                 },
                 "data_description": {
                     "included_folders": "Comma-separated list of folders where watchman should look for config files",
@@ -36,7 +37,8 @@
                     "ignored_labels": "Use labels to exclude entities from tracking",
                     "log_obfuscate": "Whether to mask entity and action names in debug logs for privacy",
                     "exclude_disabled_automation": "Exclude entities used only by disabled automations",
-                    "enforce_file_size": "Disable this to parse files larger than {max_size_kb}KB. This might increase parsing time and memory usage."
+                    "enforce_file_size": "Disable this to parse files larger than {max_size_kb}KB. This might increase parsing time and memory usage.",
+                    "max_file_size": "Maximum file size to parse in KB. Range: 100-10000. Default: 500KB. Applies only when 'Enforce max file size limit' is enabled."
                 },
                 "sections": {
                     "appearance_location_options": {

--- a/custom_components/watchman/translations/fr.json
+++ b/custom_components/watchman/translations/fr.json
@@ -26,7 +26,9 @@
                     "ignored_labels": "Étiquettes ignorées :",
                     "check_lovelace": "Analyser les tableaux de bord contrôlés par l'interface utilisateur",
                     "startup_delay": "Délai de démarrage pour l'initialisation des capteurs Watchman",
-                    "log_obfuscate": "Masquer les données sensibles"
+                    "log_obfuscate": "Masquer les données sensibles",
+                    "enforce_file_size": "Appliquer la limite de taille maximale des fichiers",
+                    "max_file_size": "Taille maximale du fichier (Ko)"
                 },
                 "data_description": {
                     "included_folders": "Liste séparée par des virgules des dossiers dans lesquels Watchman doit rechercher les fichiers de configuration",
@@ -36,7 +38,9 @@
                     "enforce_file_size": "Désactivez cette option pour analyser les fichiers de plus de {max_size_kb}Ko. Cela pourrait augmenter le temps d'analyse et l'utilisation de la mémoire.",
                     "ignored_files": "Ajoutez des motifs glob de fichiers à exclure du suivi (ex. */esphome/*)",
                     "ignored_labels": "Utiliser des étiquettes pour exclure des entités du suivi",
-                    "log_obfuscate": "Masquer les noms d'entités et de services dans les journaux pour la confidentialité"
+                    "log_obfuscate": "Masquer les noms d'entités et de services dans les journaux pour la confidentialité",
+                    "enforce_file_size": "Désactivez cette option pour analyser les fichiers de plus de {max_size_kb}Ko. Cela pourrait augmenter le temps d'analyse et l'utilisation de la mémoire.",
+                    "max_file_size": "Taille maximale du fichier à analyser en Ko. Plage : 100-10000. Par défaut : 500Ko. S'applique uniquement lorsque 'Appliquer la limite de taille maximale des fichiers' est activé."
                 },
                 "sections": {
                     "appearance_location_options": {

--- a/custom_components/watchman/translations/it.json
+++ b/custom_components/watchman/translations/it.json
@@ -1,0 +1,154 @@
+{
+    "config": {
+        "abort": {
+            "single_instance_allowed": "È consentita solo un'istanza di Watchman"
+        },
+        "step": {}
+    },
+    "options": {
+        "error": {
+            "invalid_included_folders": "included_folders deve essere un elenco di cartelle di configurazione separate da virgole",
+            "invalid_columns_width": "La larghezza della colonna del rapporto deve essere un elenco di 3 numeri interi positivi",
+            "malformed_json": "I dati dell'azione di notifica devono essere un dizionario JSON valido",
+            "unknown_service": "azione sconosciuta: `{service}`",
+            "invalid_report_path": "Il percorso del file di rapporto non è valido, il percorso non esiste"
+        },
+        "step": {
+            "init": {
+                "title": "Impostazioni Watchman",
+                "data": {
+                    "included_folders": "Cartelle da monitorare:",
+                    "ignored_items": "Entità e azioni ignorate:",
+                    "ignored_states": "Escludi dal rapporto le entità con gli stati seguenti:",
+                    "exclude_disabled_automation": "Escludi automazioni disabilitate",
+                    "ignored_files": "File ignorati:",
+                    "ignored_labels": "Etichette ignorate:",
+                    "check_lovelace": "Analizza dashboard controllate dall'interfaccia utente",
+                    "startup_delay": "Ritardo di avvio per l'inizializzazione dei sensori Watchman",
+                    "log_obfuscate": "Offusca dati sensibili nei log",
+                    "enforce_file_size": "Applica limite massimo dimensione file",
+                    "max_file_size": "Dimensione massima del file (KB)"
+                },
+                "data_description": {
+                    "included_folders": "Elenco separato da virgole delle cartelle in cui Watchman deve cercare i file di configurazione",
+                    "ignored_items": "Aggiungi entità e azioni da escludere dal monitoraggio. Supporta pattern glob (es. switch.*)",
+                    "ignored_states": "Elenco separato da virgole degli stati esclusi dal monitoraggio",
+                    "ignored_files": "Aggiungi pattern glob di file da escludere dal monitoraggio (es. */esphome/*)",
+                    "ignored_labels": "Utilizza etichette per escludere entità dal monitoraggio",
+                    "log_obfuscate": "Se mascherare i nomi di entità e azioni nei log per la privacy",
+                    "exclude_disabled_automation": "Escludi entità utilizzate solo da automazioni disabilitate",
+                    "enforce_file_size": "Disabilita questa opzione per analizzare file più grandi di {max_size_kb}KB. Ciò potrebbe aumentare il tempo di analisi e l'utilizzo della memoria.",
+                    "max_file_size": "Dimensione massima del file da analizzare in KB. Intervallo: 100-10000. Predefinito: 500KB. Si applica solo quando 'Applica limite massimo dimensione file' è abilitato."
+                },
+                "sections": {
+                    "appearance_location_options": {
+                        "name": "Aspetto e posizione del rapporto",
+                        "data": {
+                            "columns_width": "Elenco delle larghezze delle colonne del rapporto, es. 30, 7, 60",
+                            "report_header": "Intestazione personalizzata per il rapporto",
+                            "report_path": "Posizione del file di rapporto es. /config/report.txt",
+                            "friendly_names": "Aggiungi nomi descrittivi delle entità al rapporto"
+                        }
+                    }
+                },
+                "description": "[Guida alle impostazioni]({url})"
+            }
+        }
+    },
+    "services": {
+        "report": {
+            "name": "Rapporto",
+            "description": "Esegui il rapporto Watchman",
+            "fields": {
+                "create_file": {
+                    "name": "Crea file di rapporto",
+                    "description": "Se il file di rapporto testuale deve essere creato"
+                },
+                "action": {
+                    "name": "Invia rapporto come notifica",
+                    "description": "Azione di notifica facoltativa per inviare il rapporto (es. `persistent_notification.create`)"
+                },
+                "data": {
+                    "name": "Parametri dati azione di notifica",
+                    "description": "Parametri facoltativi per l'azione di notifica (es. `title: Rapporto`)"
+                },
+                "force_parsing": {
+                    "name": "Forza scansione completa configurazione",
+                    "description": "Ignora la cache e forza la rianalisi di tutti i file di configurazione indipendentemente dall'ora di modifica. Predefinito: False. Utilizzare solo se si sospettano problemi di cache."
+                },
+                "chunk_size": {
+                    "name": "Dimensione blocco messaggio di notifica",
+                    "description": "Dimensione massima del messaggio in byte. Alcuni servizi di notifica limitano la dimensione massima del messaggio. Se la dimensione del rapporto supera chunk_size, verrà inviato in più notifiche successive. (facoltativo)"
+                }
+            },
+            "sections": {
+                "advanced_options": {
+                    "name": "Opzioni avanzate"
+                }
+            }
+        },
+        "set_ignored_labels": {
+            "name": "Imposta etichette ignorate",
+            "description": "Sovrascrivi l'elenco delle etichette da ignorare.",
+            "fields": {
+                "labels": {
+                    "name": "Etichette",
+                    "description": "Elenco delle etichette da ignorare."
+                }
+            }
+        }
+    },
+    "issues": {
+        "deprecated_text_entity": {
+            "title": "L'entità {entity_id} è deprecata",
+            "description": "L'uso di `{entity_id}` è deprecato e verrà rimosso in una versione futura di Watchman. Si prega di riconfigurare le automazioni per utilizzare l'azione `watchman.set_ignored_labels`."
+        },
+        "deprecated_service_param": {
+            "title": "Il parametro del servizio {deprecated_param} è deprecato",
+            "description": "L'uso del parametro di rapporto `{deprecated_param}` è deprecato e verrà rimosso in una versione futura di Watchman. Consultare la documentazione su {url}"
+        }
+    },
+    "entity": {
+        "sensor": {
+            "last_updated": {
+                "name": "Ultimo aggiornamento"
+            },
+            "missing_entities": {
+                "name": "Entità mancanti"
+            },
+            "missing_actions": {
+                "name": "Azioni mancanti"
+            },
+            "status": {
+                "name": "Stato",
+                "state": {
+                    "waiting_for_ha": "In attesa dell'avvio di HA",
+                    "parsing": "Analisi configurazione",
+                    "idle": "Inattivo"
+                }
+            },
+            "parse_duration": {
+                "name": "Durata analisi"
+            },
+            "last_parse": {
+                "name": "Ultima analisi"
+            },
+            "processed_files": {
+                "name": "File elaborati"
+            },
+            "ignored_files": {
+                "name": "File ignorati"
+            }
+        },
+        "button": {
+            "create_report_file": {
+                "name": "Crea file di rapporto"
+            }
+        },
+        "text": {
+            "ignored_labels": {
+                "name": "Etichette ignorate"
+            }
+        }
+    }
+}

--- a/custom_components/watchman/translations/pt.json
+++ b/custom_components/watchman/translations/pt.json
@@ -26,7 +26,9 @@
                     "ignored_labels": "Etiquetas ignoradas:",
                     "check_lovelace": "Analisar dashboards controlados pela UI",
                     "startup_delay": "Atraso de inicialização para a inicialização dos sensores do watchman",
-                    "log_obfuscate": "Ofuscar dados sensíveis nos logs"
+                    "log_obfuscate": "Ofuscar dados sensíveis nos logs",
+                    "enforce_file_size": "Impor limite máximo de tamanho de arquivo",
+                    "max_file_size": "Tamanho máximo do ficheiro (KB)"
                 },
                 "data_description": {
                     "included_folders": "Lista de pastas separadas por vírgulas onde o watchman deve procurar arquivos de configuração",
@@ -36,7 +38,9 @@
                     "enforce_file_size": "Desative isto para analisar arquivos maiores que {max_size_kb}KB. Isso pode aumentar o tempo de análise e o uso de memória.",
                     "ignored_files": "Adicione padrões glob de arquivos a excluir do rastreamento (ex. */esphome/*)",
                     "ignored_labels": "Usar etiquetas para excluir entidades do rastreamento",
-                    "log_obfuscate": "Se os nomes de entidades e serviços devem ser ocultados nos logs para privacidade"
+                    "log_obfuscate": "Se os nomes de entidades e serviços devem ser ocultados nos logs para privacidade",
+                    "enforce_file_size": "Desative isto para analisar arquivos maiores que {max_size_kb}KB. Isso pode aumentar o tempo de análise e o uso de memória.",
+                    "max_file_size": "Tamanho máximo do ficheiro a analisar em KB. Intervalo: 100-10000. Padrão: 500KB. Aplica-se apenas quando 'Impor limite máximo de tamanho de arquivo' está ativado."
                 },
                 "sections": {
                     "appearance_location_options": {

--- a/custom_components/watchman/translations/sk.json
+++ b/custom_components/watchman/translations/sk.json
@@ -26,7 +26,9 @@
                     "ignored_labels": "Ignorované štítky:",
                     "check_lovelace": "Analyzovať ovládané UI ovládacie panely",
                     "startup_delay": "Oneskorenie spustenia pre inicializáciu senzorov watchman",
-                    "log_obfuscate": "Zatmavenie citlivých údajov"
+                    "log_obfuscate": "Zatmavenie citlivých údajov",
+                    "enforce_file_size": "Vynútiť limit maximálnej veľkosti súboru",
+                    "max_file_size": "Maximálna veľkosť súboru (KB)"
                 },
                 "data_description": {
                     "included_folders": "Čiarkami oddelený zoznam priečinkov, kde by mal watchman hľadať konfiguračné súbory",
@@ -36,7 +38,9 @@
                     "enforce_file_size": "Vypnite túto možnosť, ak chcete analyzovať súbory väčšie ako {max_size_kb}KB. Môže to zvýšiť čas analýzy a využitie pamäte.",
                     "ignored_files": "Pridajte glob vzory súborov na vylúčenie zo sledovania (napr. */esphome/*)",
                     "ignored_labels": "Použiť štítky na vylúčenie entít zo sledovania",
-                    "log_obfuscate": "Či sa majú v logoch z dôvodu ochrany osobných údajov maskovať názvy entít a služieb"
+                    "log_obfuscate": "Či sa majú v logoch z dôvodu ochrany osobných údajov maskovať názvy entít a služieb",
+                    "enforce_file_size": "Vypnite túto možnosť, ak chcete analyzovať súbory väčšie ako {max_size_kb}KB. Môže to zvýšiť čas analýzy a využitie pamäte.",
+                    "max_file_size": "Maximálna veľkosť súboru na analýzu v KB. Rozsah: 100-10000. Predvolené: 500KB. Platí iba vtedy, keď je povolená možnosť 'Vynútiť limit maximálnej veľkosti súboru'."
                 },
                 "sections": {
                     "appearance_location_options": {

--- a/custom_components/watchman/utils/parser_core.py
+++ b/custom_components/watchman/utils/parser_core.py
@@ -698,7 +698,7 @@ def _is_file_ignored(path_obj: Path, cwd: Path, ignored_patterns: list[str]) -> 
     return False
 
 
-def _scan_files_sync(root_path: str, ignored_patterns: list[str], enforce_file_size: bool = True) -> tuple[list[dict[str, Any]], int]:
+def _scan_files_sync(root_path: str, ignored_patterns: list[str], enforce_file_size: bool = True, max_file_size: int = MAX_FILE_SIZE) -> tuple[list[dict[str, Any]], int]:
     """Scan files syncronously using os.walk (blocking).
 
     Executed as a single job in the executor.
@@ -727,8 +727,8 @@ def _scan_files_sync(root_path: str, ignored_patterns: list[str], enforce_file_s
             # Stat
             try:
                 stat_res = abs_path_obj.stat()
-                if enforce_file_size and stat_res.st_size > MAX_FILE_SIZE:
-                    _LOGGER.warning(f"Parser: file {abs_path_obj} skipped due to size ({stat_res.st_size} > {MAX_FILE_SIZE}).")
+                if enforce_file_size and stat_res.st_size > max_file_size:
+                    _LOGGER.warning(f"Parser: file {abs_path_obj} skipped due to size ({stat_res.st_size} > {max_file_size}).")
                     _LOGGER.warning('Switch off "Enforce max file size limit" in the integration options to parse large files.')
                     ignored_count += 1
                     continue
@@ -768,8 +768,8 @@ def _scan_files_sync(root_path: str, ignored_patterns: list[str], enforce_file_s
 
                 try:
                     stat_res = file_path_obj.stat()
-                    if enforce_file_size and stat_res.st_size > MAX_FILE_SIZE:
-                        _LOGGER.warning(f"Parser: file {abs_path_obj} skipped due to size ({stat_res.st_size} > {MAX_FILE_SIZE}).")
+                    if enforce_file_size and stat_res.st_size > max_file_size:
+                        _LOGGER.warning(f"Parser: file {file_path_obj} skipped due to size ({stat_res.st_size} > {max_file_size}).")
                         _LOGGER.warning('Switch off "Enforce max file size limit" in the integration options to parse large files.')
                         ignored_count += 1
                         continue
@@ -930,12 +930,12 @@ class WatchmanParser:
             path.unlink(missing_ok=True)
             return self._create_fresh_db(db_path)
 
-    async def _async_scan_files(self, root_path: str, ignored_patterns: list[str], enforce_file_size: bool = True) -> tuple[list[dict[str, Any]], int]:
+    async def _async_scan_files(self, root_path: str, ignored_patterns: list[str], enforce_file_size: bool = True, max_file_size: int = MAX_FILE_SIZE) -> tuple[list[dict[str, Any]], int]:
         """Phase 1: Synchronous file scanning (offloaded to thread).
 
         Calls _scan_files_sync in executor.
         """
-        return await self.executor(_scan_files_sync, root_path, ignored_patterns, enforce_file_size)
+        return await self.executor(_scan_files_sync, root_path, ignored_patterns, enforce_file_size, max_file_size)
 
     async def async_scan(
         self,
@@ -945,6 +945,7 @@ class WatchmanParser:
         custom_domains: list[str] | None = None,
         base_path: str | None = None,
         enforce_file_size: bool = True,
+        max_file_size: int = MAX_FILE_SIZE,
         ignore_mtime: bool = False,
     ) -> ParseResult | None:
         """Orchestrates the scanning process.
@@ -967,7 +968,7 @@ class WatchmanParser:
             )
             scan_time = time.monotonic()
             files_scanned, ignored_count = await self._async_scan_files(
-                root_path, ignored_files, enforce_file_size
+                root_path, ignored_files, enforce_file_size, max_file_size
             )
             _LOGGER.debug(
                 f"Parser (Scan): Found {len(files_scanned)} files in {(time.monotonic() - scan_time):.3f} sec"
@@ -1244,6 +1245,7 @@ class WatchmanParser:
         custom_domains: list[str] | None = None,
         base_path: str | None = None,
         enforce_file_size: bool = True,
+        max_file_size: int = MAX_FILE_SIZE,
     ) -> ParseResult | None:
         """Parse configuration files (main function).
 
@@ -1253,6 +1255,8 @@ class WatchmanParser:
             ignore_mtime (bool): if false, files witch unchanged modification time will be not be parsed
             custom_domains: additional domains provided by customer integrations which should not be ignored by WM, e.g. xiaomi_miio.*
             base_path: root path to make file paths relative in the database
+            enforce_file_size: whether to enforce max_file_size limit
+            max_file_size: maximum file size in bytes (default: MAX_FILE_SIZE)
 
         Returns:
             parse_result (ParseResult): Operational statistics.
@@ -1264,5 +1268,6 @@ class WatchmanParser:
             custom_domains=custom_domains,
             base_path=base_path,
             enforce_file_size=enforce_file_size,
+            max_file_size=max_file_size,
             ignore_mtime=ignore_mtime,
         )

--- a/custom_components/watchman/utils/utils.py
+++ b/custom_components/watchman/utils/utils.py
@@ -25,6 +25,7 @@ from ..const import (
     CONF_IGNORED_STATES,
     CONF_INCLUDED_FOLDERS,
     CONF_LOG_OBFUSCATE,
+    CONF_MAX_FILE_SIZE,
     CONF_REPORT_PATH,
     CONF_SECTION_APPEARANCE_LOCATION,
     CONF_STARTUP_DELAY,
@@ -119,6 +120,7 @@ def get_config(hass: HomeAssistant, key: str, default: Any | None = None) -> Any
         CONF_STARTUP_DELAY,
         CONF_LOG_OBFUSCATE,
         CONF_ENFORCE_FILE_SIZE,
+        CONF_MAX_FILE_SIZE,
     ]:
         return get_val(entry.data, key)
 

--- a/tests/test_file_size_limit.py
+++ b/tests/test_file_size_limit.py
@@ -12,12 +12,14 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.watchman.const import (
     DOMAIN,
     CONF_ENFORCE_FILE_SIZE,
+    CONF_MAX_FILE_SIZE,
     CONF_STARTUP_DELAY,
     CONF_SECTION_APPEARANCE_LOCATION,
     CONF_REPORT_PATH,
     CONF_HEADER,
     CONF_COLUMNS_WIDTH,
     DB_FILENAME,
+    DEFAULT_OPTIONS,
 )
 from custom_components.watchman.utils.parser_const import MAX_FILE_SIZE
 
@@ -221,3 +223,85 @@ async def test_parser_file_size_limit_end_to_end(hass: HomeAssistant, large_file
         
         await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
+
+
+@pytest.mark.asyncio
+async def test_options_flow_max_file_size_present_and_persists(hass: HomeAssistant):
+    """Test that max_file_size is present in OptionsFlow schema and persists on change."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="test_entry_max_file_size_options",
+        version=2,
+        minor_version=7,
+        data={
+            CONF_ENFORCE_FILE_SIZE: True,
+            CONF_MAX_FILE_SIZE: 500,
+            CONF_STARTUP_DELAY: 0,
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    with patch("custom_components.watchman.config_flow.async_is_valid_path", return_value=True):
+        try:
+            result = await hass.config_entries.options.async_init(config_entry.entry_id)
+            assert result["type"] == data_entry_flow.FlowResultType.FORM
+            assert CONF_MAX_FILE_SIZE in result["data_schema"].schema
+
+            user_input = {
+                CONF_ENFORCE_FILE_SIZE: True,
+                CONF_MAX_FILE_SIZE: 1000,
+                CONF_STARTUP_DELAY: 30,
+                CONF_SECTION_APPEARANCE_LOCATION: {
+                    CONF_REPORT_PATH: "/config/report.txt",
+                    CONF_HEADER: "-== Watchman Report ==-",
+                    CONF_COLUMNS_WIDTH: "30, 8, 60",
+                },
+            }
+
+            result = await hass.config_entries.options.async_configure(
+                result["flow_id"], user_input=user_input
+            )
+            await hass.async_block_till_done()
+
+            assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+            assert config_entry.data[CONF_MAX_FILE_SIZE] == 1000
+        finally:
+            await hass.config_entries.async_unload(config_entry.entry_id)
+            await hass.async_block_till_done()
+
+
+@pytest.mark.asyncio
+async def test_parser_respects_configurable_max_file_size(tmp_path, caplog):
+    """Test parser skips file exceeding custom max_file_size and passes file below it."""
+    from custom_components.watchman.utils.parser_core import WatchmanParser
+
+    db_path = tmp_path / "watchman.db"
+    parser = WatchmanParser(str(db_path))
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    # 200 KB file — above 100 KB limit, below 500 KB default
+    medium_file = config_dir / "medium.yaml"
+    medium_file.write_text("#" * (200 * 1024 + 10), encoding="utf-8")
+
+    normal_file = config_dir / "normal.yaml"
+    normal_file.write_text(
+        "sensor:\n  - platform: template\n    sensors:\n      test:\n        value_template: '{{ states.sensor.valid }}'",
+        encoding="utf-8",
+    )
+
+    # With 100 KB limit — medium file should be skipped
+    await parser.async_parse(str(config_dir), [], enforce_file_size=True, max_file_size=100 * 1024)
+    assert "skipped due to size" in caplog.text
+    assert str(medium_file) in caplog.text
+
+    caplog.clear()
+    parser2 = WatchmanParser(str(tmp_path / "watchman2.db"))
+
+    # With 300 KB limit — medium file should pass (200 KB < 300 KB)
+    await parser2.async_parse(str(config_dir), [], enforce_file_size=True, max_file_size=300 * 1024)
+    assert "skipped due to size" not in caplog.text

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -5,6 +5,7 @@ from custom_components.watchman import async_migrate_entry, async_setup_entry
 from custom_components.watchman.const import (
     CONF_IGNORED_FILES,
     CONF_IGNORED_ITEMS,
+    CONF_MAX_FILE_SIZE,
     CONF_STARTUP_DELAY,
     CONFIG_ENTRY_MINOR_VERSION,
     CONFIG_ENTRY_VERSION,
@@ -75,8 +76,8 @@ async def test_migrate_v2_minor_upgrade_forces_delay(hass: HomeAssistant):
     # Should be updated to default (30)
     assert updated_data[CONF_STARTUP_DELAY] == DEFAULT_OPTIONS[CONF_STARTUP_DELAY]
 
-    # It continues to migrate to v6
-    assert kwargs["minor_version"] == 6
+    # It continues to migrate to v7
+    assert kwargs["minor_version"] == 7
     assert updated_data[CONF_ENFORCE_FILE_SIZE] is True
 
 @pytest.mark.asyncio
@@ -103,8 +104,8 @@ async def test_migrate_v2_minor_upgrade_preserves_valid_delay(hass: HomeAssistan
     updated_data = kwargs["data"]
 
     assert updated_data[CONF_STARTUP_DELAY] == 60
-    # It continues to migrate to v6
-    assert kwargs["minor_version"] == 6
+    # It continues to migrate to v7
+    assert kwargs["minor_version"] == 7
     assert updated_data[CONF_ENFORCE_FILE_SIZE] is True
 
 @pytest.mark.asyncio
@@ -112,8 +113,8 @@ async def test_migrate_v2_current_version_no_op(hass: HomeAssistant):
     """Test no migration needed if version is current."""
     mock_entry = MagicMock(spec=ConfigEntry)
     mock_entry.version = 2
-    # Set to current minor version (6)
-    mock_entry.minor_version = 6
+    # Set to current minor version (7)
+    mock_entry.minor_version = 7
     mock_entry.data = {
         CONF_STARTUP_DELAY: 5 # Should remain 5 as migration logic won't run
     }
@@ -152,8 +153,8 @@ async def test_migrate_v2_minor_upgrade_adds_obfuscation(hass: HomeAssistant):
 
     assert CONF_LOG_OBFUSCATE in updated_data
     assert updated_data[CONF_LOG_OBFUSCATE] is True
-    # It upgrades to 6 eventually
-    assert kwargs["minor_version"] == 6
+    # It upgrades to 7 eventually
+    assert kwargs["minor_version"] == 7
     assert updated_data[CONF_ENFORCE_FILE_SIZE] is True
 
 @pytest.mark.asyncio
@@ -182,7 +183,7 @@ async def test_migrate_v2_minor_upgrade_adds_enforce_file_size(hass: HomeAssista
 
     assert CONF_ENFORCE_FILE_SIZE in updated_data
     assert updated_data[CONF_ENFORCE_FILE_SIZE] is True
-    assert kwargs["minor_version"] == 6
+    assert kwargs["minor_version"] == 7
 
 @pytest.mark.asyncio
 async def test_migrate_v2_downgrade_compatibility(hass: HomeAssistant):
@@ -256,7 +257,7 @@ async def test_migrate_minor_v5_to_v6_preserves_ignored_items(hass: HomeAssistan
             result = await hass.config_entries.async_setup(mock_entry.entry_id)
             await hass.async_block_till_done()
             assert result is True
-            assert mock_entry.minor_version == 6
+            assert mock_entry.minor_version == 7
             assert mock_entry.data[CONF_IGNORED_ITEMS] == ["sensor.foo", "timer.*", "switch.bar"]
             assert mock_entry.data[CONF_IGNORED_FILES] == ["/config/esphome/*", "*/blueprints/*"]
         finally:
@@ -295,7 +296,7 @@ async def test_migrate_minor_v5_to_v6_empty_strings(hass: HomeAssistant):
             result = await hass.config_entries.async_setup(mock_entry.entry_id)
             await hass.async_block_till_done()
             assert result is True
-            assert mock_entry.minor_version == 6
+            assert mock_entry.minor_version == 7
             assert mock_entry.data[CONF_IGNORED_ITEMS] == []
             assert mock_entry.data[CONF_IGNORED_FILES] == []
         finally:
@@ -334,7 +335,7 @@ async def test_migrate_minor_v5_to_v6_already_list(hass: HomeAssistant):
             result = await hass.config_entries.async_setup(mock_entry.entry_id)
             await hass.async_block_till_done()
             assert result is True
-            assert mock_entry.minor_version == 6
+            assert mock_entry.minor_version == 7
             assert mock_entry.data[CONF_IGNORED_ITEMS] == ["sensor.foo"]
             assert mock_entry.data[CONF_IGNORED_FILES] == []
         finally:
@@ -375,9 +376,45 @@ async def test_migrate_v1_to_v2_ignored_fields_are_list(hass: HomeAssistant):
             await hass.async_block_till_done()
             assert result is True
             assert mock_entry.version == 2
-            assert mock_entry.minor_version == 6
+            assert mock_entry.minor_version == 7
             assert mock_entry.data[CONF_IGNORED_ITEMS] == ["sensor.foo", "timer.*"]
             assert mock_entry.data[CONF_IGNORED_FILES] == ["/config/esphome/*"]
+        finally:
+            await hass.config_entries.async_unload(mock_entry.entry_id)
+            await hass.async_block_till_done()
+
+
+@pytest.mark.asyncio
+async def test_migrate_minor_v6_to_v7_adds_max_file_size(hass: HomeAssistant):
+    """Test migration from minor v6 to v7 adds max_file_size with default value."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="test_v6_to_v7_max_file_size",
+        version=2,
+        minor_version=6,
+        data={
+            **DEFAULT_OPTIONS,
+        },
+    )
+    mock_entry.add_to_hass(hass)
+
+    with patch("custom_components.watchman.async_get_integration"), \
+         patch("custom_components.watchman.WatchmanHub"), \
+         patch("custom_components.watchman.WatchmanCoordinator") as mock_coordinator_cls, \
+         patch("custom_components.watchman.WatchmanServicesSetup"), \
+         patch.object(hass.config_entries, "async_forward_entry_setups"):
+
+        mock_coordinator = mock_coordinator_cls.return_value
+        mock_coordinator.async_load_stats = AsyncMock()
+        mock_coordinator.async_shutdown = AsyncMock()
+        mock_coordinator.safe_mode = False
+
+        try:
+            result = await hass.config_entries.async_setup(mock_entry.entry_id)
+            await hass.async_block_till_done()
+            assert result is True
+            assert mock_entry.minor_version == 7
+            assert mock_entry.data[CONF_MAX_FILE_SIZE] == DEFAULT_OPTIONS[CONF_MAX_FILE_SIZE]
         finally:
             await hass.config_entries.async_unload(mock_entry.entry_id)
             await hass.async_block_till_done()

--- a/tests/test_ui_defaults.py
+++ b/tests/test_ui_defaults.py
@@ -2,6 +2,8 @@
 import pytest
 from custom_components.watchman.const import (
     CONF_LOG_OBFUSCATE,
+    CONF_MAX_FILE_SIZE,
+    DEFAULT_OPTIONS,
     DOMAIN,
 )
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -57,6 +59,29 @@ async def test_options_flow_missing_key_behavior(hass: HomeAssistant):
         
         # And it should be True (default)
         assert config_entry.data.get(CONF_LOG_OBFUSCATE) is True
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+
+@pytest.mark.asyncio
+async def test_options_flow_missing_max_file_size_migrated(hass: HomeAssistant):
+    """Test that missing max_file_size key is populated with default after migration."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="test_entry_max_file_size",
+        version=2,
+        minor_version=6,
+        data={},  # Missing CONF_MAX_FILE_SIZE
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    try:
+        assert CONF_MAX_FILE_SIZE in config_entry.data
+        assert config_entry.data[CONF_MAX_FILE_SIZE] == DEFAULT_OPTIONS[CONF_MAX_FILE_SIZE]
     finally:
         await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Added a new setting that lets users choose how large configuration files can be before Watchman skips them. 
Previously, this was fixed at 500 KB. Now users can adjust it from 100 KB up to 10 MB (10,000 KB) through the settings menu.

<img width="596" height="822" alt="image" src="https://github.com/user-attachments/assets/04d445c5-a1b4-4df3-b369-8f69e0274e1a" />


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Users with large automation files (bigger than 500 KB) were seeing their files skipped with a warning message. 
<img width="1052" height="258" alt="image" src="https://github.com/user-attachments/assets/581fb217-bf83-48d0-b99d-668015ce300a" />


This change allows them to increase the limit so Watchman can parse their files.
<img width="1040" height="273" alt="image" src="https://github.com/user-attachments/assets/774f9fb0-fdf6-45e1-92b8-186e7904b0aa" />

The default stays at 500 KB, so nothing changes for existing users unless they want to adjust it.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Tested that the new setting appears correctly in the UI
- Verified the default value is still 500 KB (no change in behaviour)
- Confirmed large files are now parsed when the limit is increased
- Confirmed large files are now parsed when the limit check is disabled

Before the setting change
<img width="328" height="524" alt="image" src="https://github.com/user-attachments/assets/17a69c9d-8f0b-4f98-9eec-1cc22d178bf1" />

After
<img width="331" height="522" alt="image" src="https://github.com/user-attachments/assets/bc000b43-d2a2-467a-a362-f9c9a2dfe7a3" />


Additionally, ITALIAN translations are introduced in the PR

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
